### PR TITLE
Make it work with latest Astarte SDK version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl DeviceManager {
 
                 w.send_object(
                     "io.edgehog.devicemanager.SystemStatus",
-                    "/systemStatus/",
+                    "/systemStatus",
                     systatus,
                 )
                 .await


### PR DESCRIPTION
Publish data to `/systemStatus` instead of `/systemStatus/`. 