### PR TITLE
Implement io.edgehog.devicemanager.RuntimeInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,7 @@ dependencies = [
  "log",
  "nix",
  "procfs",
+ "rustc_version_runtime",
  "serde",
  "thiserror",
  "tokio",
@@ -1294,6 +1295,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de8ecd7fad7731f306f69b6e10ec5a3178c61e464dcc06979427aa4cc891145"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1392,21 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ clap = { version = "3.0.13", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 serde = "1.0.136"
 procfs = "0.12.0"
+rustc_version_runtime = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@
 name = "edgehog-device-runtime"
 version = "0.1.0"
 edition = "2021"
+homepage = "https://github.com/edgehog-device-manager/edgehog-device-runtime"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following information are sent to remote Edgehog instance:
 - OS info (data is read from `/etc/os-release`)
 - Hardware info
 - System status (data is read from proc filesystem)
+- Runtime info and compiler version
 
 ## How it Works
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,16 +89,25 @@ impl DeviceManager {
     pub async fn send_initial_telemetry(&self) -> Result<(), DeviceManagerError> {
         let device = &self.sdk;
 
-        for i in telemetry::os_info::get_os_info()? {
-            device
-                .send("io.edgehog.devicemanager.OSInfo", &i.0, i.1)
-                .await?;
-        }
+        let data = [
+            (
+                "io.edgehog.devicemanager.OSInfo",
+                telemetry::os_info::get_os_info()?,
+            ),
+            (
+                "io.edgehog.devicemanager.HardwareInfo",
+                telemetry::hardware_info::get_hardware_info()?,
+            ),
+            (
+                "io.edgehog.devicemanager.RuntimeInfo",
+                telemetry::runtime_info::get_runtime_info()?,
+            ),
+        ];
 
-        for i in telemetry::hardware_info::get_hardware_info()? {
-            device
-                .send("io.edgehog.devicemanager.HardwareInfo", &i.0, i.1)
-                .await?;
+        for (ifc, fields) in data {
+            for (path, data) in fields {
+                device.send(ifc, &path, data).await?;
+            }
         }
 
         Ok(())

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -20,4 +20,5 @@
 
 pub(crate) mod hardware_info;
 pub(crate) mod os_info;
+pub(crate) mod runtime_info;
 pub(crate) mod system_status;

--- a/src/telemetry/runtime_info.rs
+++ b/src/telemetry/runtime_info.rs
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::error::DeviceManagerError;
+use astarte_sdk::types::AstarteType;
+use std::collections::HashMap;
+
+/// get structured data for `io.edgehog.devicemanager.RuntimeInfo` interface
+pub fn get_runtime_info() -> Result<HashMap<String, AstarteType>, DeviceManagerError> {
+    let mut ret: HashMap<String, AstarteType> = HashMap::new();
+
+    if let Ok(f) = std::env::var("CARGO_PKG_NAME") {
+        ret.insert("/name".to_owned(), f.into());
+    }
+
+    if let Ok(f) = std::env::var("CARGO_PKG_HOMEPAGE") {
+        ret.insert("/url".to_owned(), f.into());
+    }
+
+    if let Ok(f) = std::env::var("CARGO_PKG_VERSION") {
+        ret.insert("/version".to_owned(), f.into());
+    }
+
+    ret.insert("/environment".to_owned(), "Rust".to_owned().into());
+
+    Ok(ret)
+}

--- a/src/telemetry/runtime_info.rs
+++ b/src/telemetry/runtime_info.rs
@@ -38,7 +38,10 @@ pub fn get_runtime_info() -> Result<HashMap<String, AstarteType>, DeviceManagerE
         ret.insert("/version".to_owned(), f.into());
     }
 
-    ret.insert("/environment".to_owned(), "Rust".to_owned().into());
+    ret.insert(
+        "/environment".to_owned(),
+        format!("Rust {}", rustc_version_runtime::version()).into(),
+    );
 
     Ok(ret)
 }


### PR DESCRIPTION
closes #5 

`/environment` is statically set to "Rust" since there's no standard way to get the compiler version for a rust program