### PR TITLE
Add systemd library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if",
+ "memchr",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +424,7 @@ dependencies = [
  "rustc_version_runtime",
  "serde",
  "serde_json",
+ "systemd",
  "thiserror",
  "tokio",
  "toml",
@@ -515,7 +532,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -523,6 +561,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -868,6 +912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsystemd-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed080163caa59cc29b34bce2209b737149a4bac148cd9a8b04e4c12822798119"
+dependencies = [
+ "build-env",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,7 +1114,7 @@ checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-sys",
@@ -1812,6 +1867,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afec0101d9ae8ab26aedf0840109df689938ea7e538aa03df4369f1854f11562"
+dependencies = [
+ "cstr-argument",
+ "foreign-types 0.5.0",
+ "libc",
+ "libsystemd-sys",
+ "log",
+ "memchr",
+ "utf8-cstr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2130,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-cstr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ zbus = { version = "2", default-features = false, features = ["tokio"] }
 reqwest = "0.11.9"
 toml = "0.5.8"
 uuid = {version="0.8.2", features = ["v5", "v4"] }
+systemd = { version = "0.10", optional = true }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ enables remote device management using
 ## Supported Operating System
 
 At the moment only Linux-based systems are supported.
+On Linux system if `edgehog-device-runtime` is a `systemd` service, it can notify `systemd` its status changes.
+This is provided via `rust-systemd` crate that is a rust interface to `libsystemd/libelogind` APIs.
+To build the `runtime` make sure you have `libsystemd-dev` installed on your system
+and the systemd feature enabled.
+```shell
+cargo build --features systemd
+```
 
 See also [OS requirements](doc/os_requirements.md) for further information.
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ enables remote device management using
 ## Supported Operating System
 
 At the moment only Linux-based systems are supported.
-On Linux system if `edgehog-device-runtime` is a `systemd` service, it can notify `systemd` its status changes.
-This is provided via `rust-systemd` crate that is a rust interface to `libsystemd/libelogind` APIs.
+On Linux systems if `edgehog-device-runtime` is a `systemd` service, it can notify `systemd` of its status changes.
+This is provided via the `rust-systemd` crate, a Rust interface to `libsystemd/libelogind` APIs.
+
 To build the `runtime` make sure you have `libsystemd-dev` installed on your system
 and the systemd feature enabled.
+
 ```shell
 cargo build --features systemd
 ```
@@ -31,6 +33,7 @@ The following information are sent to remote Edgehog instance:
 - System status (data is read from proc filesystem)
 - Runtime info and compiler version
 - OTA update using RAUC
+- `Edgehog Device Runtime` status changes via systemd.
 
 ## How it Works
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod ota_handler;
 mod power_management;
 mod rauc;
 mod telemetry;
+pub mod wrapper;
 
 #[derive(Debug, Deserialize)]
 pub struct DeviceManagerOptions {
@@ -71,6 +72,7 @@ impl DeviceManager {
         .build();
         info!("Starting");
 
+        wrapper::systemd::systemd_notify_status("Initializing");
         let device = astarte_sdk::AstarteSdk::new(&sdk_options).await?;
 
         let mut ota_handler = ota_handler::OTAHandler::new(&opts).await?;
@@ -93,6 +95,7 @@ impl DeviceManager {
     }
 
     pub async fn run(&mut self) {
+        wrapper::systemd::systemd_notify_status("Running");
         let w = self.sdk.clone();
         tokio::task::spawn(async move {
             loop {
@@ -148,6 +151,7 @@ impl DeviceManager {
     }
 
     pub async fn init(&self) -> Result<(), DeviceManagerError> {
+        wrapper::systemd::systemd_notify_status("Sending initial telemetry");
         self.send_initial_telemetry().await?;
 
         Ok(())

--- a/src/wrapper/mod.rs
+++ b/src/wrapper/mod.rs
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pub mod systemd;

--- a/src/wrapper/systemd.rs
+++ b/src/wrapper/systemd.rs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#[cfg(feature = "systemd")]
+use systemd::daemon;
+#[cfg(feature = "systemd")]
+use systemd::daemon::{STATE_ERRNO, STATE_READY, STATE_STATUS};
+
+#[allow(unused)]
+pub fn systemd_notify_status(service_status: &str) {
+    #[cfg(feature = "systemd")]
+    {
+        let systemd_state_pairs = vec![(STATE_STATUS, service_status)];
+        daemon::notify(false, systemd_state_pairs.iter());
+    }
+}
+
+#[allow(unused)]
+pub fn systemd_notify_ready_status(service_status: &str) {
+    #[cfg(feature = "systemd")]
+    {
+        let systemd_state_pairs = vec![(STATE_READY, "1"), (STATE_STATUS, service_status)];
+        daemon::notify(false, systemd_state_pairs.iter());
+    }
+}
+
+#[allow(unused)]
+pub fn systemd_notify_errno_status(err_no: i32, service_status: &str) {
+    #[cfg(feature = "systemd")]
+    {
+        let systemd_state_pairs = vec![
+            (STATE_ERRNO, err_no.to_string()),
+            (STATE_STATUS, service_status),
+        ];
+        daemon::notify(false, systemd_state_pairs.iter());
+    }
+}


### PR DESCRIPTION
Add rust-systemd as optional library

- Notify service manager about Device Runtime status changes
- Create an initial wrapper around `rust-systemd` crate because not all systems support systemd.
- Register a custom panic hook for sending `PanicInfo` to systemd status.

    
