### PR TITLE
Add tests to os_info

### DIFF
--- a/src/telemetry/os_info.rs
+++ b/src/telemetry/os_info.rs
@@ -100,4 +100,32 @@ BUG_REPORT_URL="https://bugs.debian.org/""#;
         assert_eq!(data["/osName"], "Debian GNU/Linux");
         assert_eq!(data["/osVersion"], "11");
     }
+
+    #[test]
+    fn os_release_parsing_with_middle_empty_line() {
+        let file = r#"NAME="Debian GNU/Linux"
+
+VERSION_ID="11""#;
+
+        let data = parse_os_info(file).unwrap();
+        assert_eq!(data["/osName"], "Debian GNU/Linux");
+        assert_eq!(data["/osVersion"], "11");
+    }
+
+    #[test]
+    fn os_release_with_only_name() {
+        let file = r#"NAME="Arch Linux"#;
+
+        let data = parse_os_info(file).unwrap();
+        assert_eq!(data["/osName"], "Arch Linux");
+        assert!(!data.contains_key("/osVersion"));
+    }
+
+    #[test]
+    fn os_release_malformed() {
+        let file = r#"NAM["Arch Linux"@@"#;
+
+        let data = parse_os_info(file).unwrap();
+        assert!(data.is_empty());
+    }
 }


### PR DESCRIPTION
- Check the behaviour if os_release contains an empty line in the middle.
- Check the behaviour if os_release contains only the os_name.
- Check the behaviour if os_release file is malformed.
- Split parse_os_info function.
- Separate key_value parsing from osName and osVersion.
- Add tests to parse_key_value line function.