### PR TITLE
Add OS requirements doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ enables remote device management using
 
 At the moment only Linux-based systems are supported.
 
+See also [OS requirements](doc/os_requirements.md) for further information.
+
 ## Implemented Features
 
 The following information are sent to remote Edgehog instance:

--- a/doc/os_requirements.md
+++ b/doc/os_requirements.md
@@ -1,0 +1,15 @@
+<!---
+  Copyright 2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# OS Requirements
+
+Edgehog Device Runtime has a number of requirements in order to provide device management features.
+
+## Required Libraries
+
+## Runtime Dependencies
+
+## Filesystem Layout


### PR DESCRIPTION
Add OS requirements in order to make Edgehog Device Runtime easier to integrate.