### PR TITLE
Implement io.edgehog.devicemanager.Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "astarte_sdk"
 version = "0.1.0"
-source = "git+https://github.com/astarte-platform/astarte-device-sdk-rust.git#45e41c5fe8d80bb3e49b181c7ea0f3fdef8a4183"
+source = "git+https://github.com/astarte-platform/astarte-device-sdk-rust.git#b70b5cea616e3c0f719a96e2cbae640c24b7f91c"
 dependencies = [
  "async-trait",
  "base64",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use log::error;
+
+/// handle io.edgehog.devicemanager.Commands
+pub(crate) fn execute_command(command: &str) {
+    match command {
+        "Reboot" => {
+            crate::power_management::reboot().unwrap();
+        }
+        _ => {
+            error!("command not recognized");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,16 +18,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_sdk::AstarteSdk;
+use std::collections::HashMap;
+
+use astarte_sdk::{Aggregation, AstarteSdk};
 pub mod error;
 mod ota_handler;
+mod power_management;
 mod rauc;
 mod telemetry;
 
 use astarte_sdk::builder::AstarteOptions;
+use astarte_sdk::types::AstarteType;
 use error::DeviceManagerError;
-use log::{debug, info};
-use tokio::sync::mpsc::{Receiver, Sender};
+use log::{info, warn};
+use tokio::sync::mpsc::Sender;
 
 pub struct DeviceManagerOptions {
     pub realm: String,
@@ -40,7 +44,8 @@ pub struct DeviceManagerOptions {
 }
 pub struct DeviceManager {
     sdk: AstarteSdk,
-    ota_event_channel: Sender<astarte_sdk::Clientbound>,
+    //we pass the ota event through a channel, to avoid blocking the main loop
+    ota_event_channel: Sender<HashMap<String, AstarteType>>,
 }
 
 impl DeviceManager {
@@ -61,10 +66,7 @@ impl DeviceManager {
 
         ota_handler.ensure_pending_ota_response(&device).await?;
 
-        let (tx, mut rx): (
-            Sender<astarte_sdk::Clientbound>,
-            Receiver<astarte_sdk::Clientbound>,
-        ) = tokio::sync::mpsc::channel(32);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
 
         let sdk_clone = device.clone();
         tokio::spawn(async move {
@@ -99,12 +101,28 @@ impl DeviceManager {
 
         loop {
             match self.sdk.poll().await {
-                Ok(data) => {
-                    debug!("incoming: {:?}", data);
+                Ok(clientbound) => {
+                    println!("incoming: {:?}", clientbound);
 
-                    if data.interface == "io.edgehog.devicemanager.OTARequest" {
-                        //using a channel to avoid blocking the main loop
-                        self.ota_event_channel.send(data).await.unwrap();
+                    match (
+                        clientbound.interface.as_str(),
+                        clientbound
+                            .path
+                            .trim_matches('/')
+                            .split('/')
+                            .collect::<Vec<&str>>()
+                            .as_slice(),
+                        clientbound.data.clone(),
+                    ) {
+                        (
+                            "io.edgehog.devicemanager.OTARequest",
+                            ["request"],
+                            Aggregation::Object(data),
+                        ) => self.ota_event_channel.send(data).await.unwrap(),
+
+                        _ => {
+                            warn!("Receiving data from an unknown path/interface: {clientbound:?}");
+                        }
                     }
                 }
                 Err(err) => log::error!("{:?}", err),

--- a/src/power_management.rs
+++ b/src/power_management.rs
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use log::{error, info};
+
+use crate::error::DeviceManagerError;
+
+pub fn reboot() -> Result<(), DeviceManagerError> {
+    if std::env::var("DM_NO_REBOOT").is_ok() {
+        info!("Dry run, exiting");
+
+        std::process::exit(0);
+    }
+
+    // TODO: use systemd api
+    let mut cmd = std::process::Command::new("shutdown");
+    cmd.arg("-r");
+    cmd.arg("now");
+
+    let output = cmd.output()?;
+
+    if output.status.success() && output.stderr.is_empty() {
+        panic!("Reboot command was successful, bye");
+    } else {
+        error!("Reboot failed {:?}", output.stderr);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Implement `io.edgehog.devicemanager.Commands`

The new server owned interface is added with an improved selector for incoming data, removing the nested ifs that were there before

closes #19 