### PR TITLE
Make it configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ procfs = "0.12.0"
 rustc_version_runtime = "0.2"
 zbus = { version = "2", default-features = false, features = ["tokio"] }
 reqwest = "0.11.9"
+toml = "0.5.8"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Edgehog Device Runtime is a reference implementation of
 Astarte interfaces describe how data are exchanged with the remote instance, and what kind of
 features are implemented.
 
+## Configuration
+
+Edgehog Device Runtime can be configured using a [TOML](https://en.wikipedia.org/wiki/TOML) file located either in $PWD/edgehog-config.toml or /etc/edgehog/config.toml, or in a custom path, run `cargo run -- --help` for more informations.
+
+Example configuration:
+```toml
+credentials_secret = "YOUR_CREDENTIAL_SECRET"
+device_id = "YOUR_UNIQUE_DEVIDE_ID"
+pairing_url = "https://api.astarte.EXAMPLE.COM/pairing"
+realm = "examplerealm"
+interfaces_directory = "/usr/share/edgehog/astarte-interfaces/"
+state_file = "/var/lib/edgehog/state.json"
+download_directory = "/var/tmp/edgehog-updates/"
+```
+
 ## Contributing
 
 We are open to any contribution:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use edgehog_device_runtime::{error::DeviceManagerError, DeviceManagerOptions};
+use log::info;
+
+pub fn read_options(
+    override_config_file_path: Option<String>,
+) -> Result<DeviceManagerOptions, DeviceManagerError> {
+    let paths = ["edgehog-config.toml", "/etc/edgehog/config.toml"]
+        .iter()
+        .map(|f| f.to_string());
+
+    let paths = override_config_file_path
+        .into_iter()
+        .chain(paths)
+        .filter(|f| std::path::Path::new(f).exists());
+
+    if let Some(path) = paths.into_iter().next() {
+        info!("Found configuration file {path}");
+
+        let config = std::fs::read_to_string(path)?;
+
+        let config = toml::from_str::<DeviceManagerOptions>(&config)?;
+
+        Ok(config)
+    } else {
+        Err(DeviceManagerError::FatalError(
+            "Configuration file not found".to_string(),
+        ))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,4 +51,7 @@ pub enum DeviceManagerError {
 
     #[error(transparent)]
     OTAError(#[from] crate::ota_handler::OTAError),
+
+    #[error("configuration file error")]
+    ConfigFileError(#[from] toml::de::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use astarte_sdk::types::AstarteType;
 use astarte_sdk::{Aggregation, AstarteSdk};
 use error::DeviceManagerError;
 use log::{debug, info, warn};
+use serde::Deserialize;
 use std::collections::HashMap;
 use tokio::sync::mpsc::Sender;
 
@@ -33,14 +34,15 @@ mod power_management;
 mod rauc;
 mod telemetry;
 
+#[derive(Debug, Deserialize)]
 pub struct DeviceManagerOptions {
     pub realm: String,
     pub device_id: String,
     pub credentials_secret: String,
     pub pairing_url: String,
-    pub interface_json_path: String,
-    pub state_file_path: String,
-    pub download_file_path: String,
+    pub interfaces_directory: String,
+    pub state_file: String,
+    pub download_directory: String,
 }
 pub struct DeviceManager {
     sdk: AstarteSdk,
@@ -56,7 +58,7 @@ impl DeviceManager {
             &opts.credentials_secret,
             &opts.pairing_url,
         )
-        .interface_directory(&opts.interface_json_path)?
+        .interface_directory(&opts.interfaces_directory)?
         .build();
         info!("Starting");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,22 +19,15 @@
  */
 
 use clap::Parser;
-use edgehog_device_runtime::DeviceManagerOptions;
+use config::read_options;
+
+mod config;
 
 #[derive(Debug, Parser)]
 struct Cli {
-    // Realm name
+    /// Override configuration file path
     #[clap(short, long)]
-    realm: String,
-    // Device id
-    #[clap(short, long)]
-    device_id: String,
-    // Credentials secret
-    #[clap(short, long)]
-    credentials_secret: String,
-    // Pairing URL
-    #[clap(short, long)]
-    pairing_url: String,
+    configuration_file: Option<String>,
 }
 
 #[tokio::main]
@@ -42,22 +35,10 @@ async fn main() -> Result<(), edgehog_device_runtime::error::DeviceManagerError>
     env_logger::init();
 
     let Cli {
-        realm,
-        device_id,
-        credentials_secret,
-        pairing_url,
+        configuration_file: config_file_path,
     } = Parser::parse();
 
-    let options = DeviceManagerOptions {
-        realm,
-        device_id,
-        credentials_secret,
-        pairing_url,
-        interface_json_path: "./interfaces".to_string(),
-        // TODO: change following paths
-        state_file_path: "/data/dm-update".to_string(),
-        download_file_path: "/tmp/".to_string(),
-    };
+    let options = read_options(config_file_path)?;
 
     let mut dm = edgehog_device_runtime::DeviceManager::new(options).await?;
 

--- a/src/ota_handler.rs
+++ b/src/ota_handler.rs
@@ -84,8 +84,8 @@ impl<'a> OTAHandler<'a> {
 
         Ok(OTAHandler {
             rauc: proxy,
-            state_file_path: opts.state_file_path.clone(),
-            download_file_path: opts.download_file_path.clone(),
+            state_file_path: opts.state_file.clone(),
+            download_file_path: opts.download_directory.clone(),
         })
     }
 


### PR DESCRIPTION
Add toml configuration file, for example:

```
/etc/edgehog.conf
```
```toml
credentials_secret = "xxxxx"
device_id = "xxxxx"
pairing_url = "https://api.xxxxx/pairing"  
realm = "xxxxx"
interfaces_directory = "/var/lib/xxxx"
state_file = "/xxxx/xx"
download_directory = "/tmp"
```