### PR TITLE
Add 1.59.0 rust version as CI target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         toolchain:
           - stable
+          - 1.59.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -55,6 +56,7 @@ jobs:
       matrix:
         toolchain:
           - stable
+          - 1.59.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
Add `1.59.0` as target of the `rust-toolchain` in the `build` GitHub
workflow.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>