### PR TITLE
Add Repository for saving Runtime State

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod error;
 mod ota_handler;
 mod power_management;
 mod rauc;
+mod repository;
 mod telemetry;
 
 #[derive(Debug, Deserialize)]

--- a/src/repository/file_state_repository.rs
+++ b/src/repository/file_state_repository.rs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::error::DeviceManagerError;
+use crate::repository::StateRepository;
+use serde::{de::DeserializeOwned, Serialize};
+
+pub struct FileStateRepository {
+    pub path: String,
+}
+
+impl<T> StateRepository<T> for FileStateRepository
+where
+    T: Serialize + DeserializeOwned,
+{
+    fn write(&self, value: &T) -> Result<(), DeviceManagerError> {
+        let mut file = std::fs::File::create(&self.path)?;
+        let data_json = serde_json::to_string(value)?;
+        std::io::Write::write_all(&mut file, data_json.as_bytes())?;
+        Ok(())
+    }
+
+    fn read(&self) -> Result<T, DeviceManagerError> {
+        let value_str = std::fs::read_to_string(&self.path)?;
+        let value = serde_json::from_str(&value_str)?;
+        Ok(value)
+    }
+
+    fn exists(&self) -> bool {
+        std::path::Path::new(&self.path).exists()
+    }
+
+    fn clear(&self) -> Result<(), DeviceManagerError> {
+        std::fs::remove_file(&self.path)?;
+        Ok(())
+    }
+}

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pub(crate) mod file_state_repository;
+
+use crate::error::DeviceManagerError;
+use serde::{de::DeserializeOwned, Serialize};
+
+pub trait StateRepository<T>: Send + Sync {
+    fn write(&self, value: &T) -> Result<(), DeviceManagerError>;
+    fn read(&self) -> Result<T, DeviceManagerError>;
+    fn exists(&self) -> bool;
+    fn clear(&self) -> Result<(), DeviceManagerError>;
+}


### PR DESCRIPTION
Repositories encapsulate the logic required to access data sources.
They centralize common data access functionality, providing better maintainability and decoupling the infrastructure or technology
used to access the data.