### PR TITLE
Implement io.edgehog.devicemanager.config.Telemetry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,3 +81,4 @@ jobs:
           RUSTFLAGS: -Awarnings
         with:
           command: test
+          args: -- --test-threads 1

--- a/src/data/astarte.rs
+++ b/src/data/astarte.rs
@@ -37,7 +37,7 @@ pub struct Astarte {
 
 #[async_trait]
 impl Publisher for Astarte {
-    async fn send_object<T>(
+    async fn send_object<T: 'static>(
         &self,
         interface_name: &str,
         interface_path: &str,
@@ -182,6 +182,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
         assert_eq!(
             get_credentials_secret("device_id", &options, state_mock)
@@ -205,6 +206,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
         assert!(get_credentials_secret("device_id", &options, state_mock)
             .await
@@ -230,6 +232,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
 
         assert!(get_credentials_secret("device_id", &options, state_mock)
@@ -255,6 +258,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
 
         assert!(get_credentials_secret("device_id", &options, state_mock)
@@ -274,6 +278,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
 
         let state_mock = MockStateRepository::<String>::new();

--- a/src/e2e_test/e2e_test.rs
+++ b/src/e2e_test/e2e_test.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<(), edgehog_device_runtime::error::DeviceManagerError>
         store_directory: "".to_string(),
         download_directory: "".to_string(),
         astarte_ignore_ssl: Some(false),
+        telemetry_config: vec![],
     };
 
     let astarte_options = astarte_map_options(&device_options).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,21 +18,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::sync::Arc;
+
 use astarte_sdk::types::AstarteType;
 use astarte_sdk::{Aggregation, Clientbound};
 use log::{debug, info, warn};
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::fs::File;
-use std::path::Path;
-use std::sync::Arc;
-use tokio::sync::mpsc::{Receiver, Sender};
-
-use device::DeviceProxy;
-use error::DeviceManagerError;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::RwLock;
 
 use crate::data::Publisher;
+use crate::device::DeviceProxy;
+use crate::error::DeviceManagerError;
 use crate::ota::ota_handler::OTAHandler;
+use crate::telemetry::{TelemetryMessage, TelemetryPayload};
 
 mod commands;
 pub mod data;
@@ -40,7 +39,7 @@ mod device;
 pub mod error;
 mod ota;
 mod power_management;
-mod repository;
+pub mod repository;
 mod telemetry;
 pub mod wrapper;
 
@@ -63,7 +62,7 @@ pub struct DeviceManager<T: Publisher + Clone> {
     //we pass all Astarte event through a channel, to avoid blocking the main loop
     ota_event_channel: Sender<Clientbound>,
     data_event_channel: Sender<Clientbound>,
-    telemetry: Arc<telemetry::Telemetry>,
+    telemetry: Arc<RwLock<telemetry::Telemetry>>,
 }
 
 impl<T: Publisher + Clone + 'static> DeviceManager<T> {
@@ -78,20 +77,28 @@ impl<T: Publisher + Clone + 'static> DeviceManager<T> {
 
         ota_handler.ensure_pending_ota_response(&publisher).await?;
 
-        let (ota_tx, ota_rx) = tokio::sync::mpsc::channel(1);
-        let (data_tx, data_rx) = tokio::sync::mpsc::channel(32);
+        let (ota_tx, ota_rx) = channel(1);
+        let (data_tx, data_rx) = channel(32);
 
-        let tel = telemetry::Telemetry::from_default_config(opts.telemetry_config).await;
+        let (telemetry_tx, telemetry_rx) = channel(32);
+
+        let tel = telemetry::Telemetry::from_default_config(
+            opts.telemetry_config,
+            telemetry_tx,
+            opts.store_directory.clone(),
+        )
+        .await;
 
         let device_runtime = Self {
             publisher,
             ota_event_channel: ota_tx,
             data_event_channel: data_tx,
-            telemetry: Arc::new(tel),
+            telemetry: Arc::new(RwLock::new(tel)),
         };
 
         device_runtime.init_ota_event(ota_handler, ota_rx);
         device_runtime.init_data_event(data_rx);
+        device_runtime.init_telemetry_event(telemetry_rx);
         Ok(device_runtime)
     }
 
@@ -150,8 +157,10 @@ impl<T: Publisher + Clone + 'static> DeviceManager<T> {
                         Aggregation::Individual(data),
                     ) => {
                         self_telemetry
-                            .telemetry_config_event(interface_name, endpoint, data)
+                            .write()
                             .await
+                            .telemetry_config_event(interface_name, endpoint, data)
+                            .await;
                     }
                     _ => {
                         warn!("Receiving data from an unknown path/interface: {clientbound:?}");
@@ -161,24 +170,39 @@ impl<T: Publisher + Clone + 'static> DeviceManager<T> {
         });
     }
 
+    fn init_telemetry_event(&self, mut telemetry_rx: Receiver<TelemetryMessage>) {
+        let publisher = self.publisher.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = telemetry_rx.recv().await {
+                match msg.payload {
+                    TelemetryPayload::SystemStatus(data) => {
+                        let _ = publisher
+                            .send_object(
+                                "io.edgehog.devicemanager.SystemStatus",
+                                "/systemStatus",
+                                data,
+                            )
+                            .await;
+                    }
+                    TelemetryPayload::StorageUsage(data) => {
+                        let _ = publisher
+                            .send_object(
+                                "io.edgehog.devicemanager.StorageUsage",
+                                format!("/{}", msg.path).as_str(),
+                                data,
+                            )
+                            .await;
+                    }
+                };
+            }
+        });
+    }
+
     pub async fn run(&mut self) {
         wrapper::systemd::systemd_notify_status("Running");
-        let w = self.publisher.clone();
-        let tel = self.telemetry.clone();
+        let tel_clone = self.telemetry.clone();
         tokio::task::spawn(async move {
-            loop {
-                let systatus = telemetry::system_status::get_system_status().unwrap();
-
-                w.send_object(
-                    "io.edgehog.devicemanager.SystemStatus",
-                    "/systemStatus",
-                    systatus,
-                )
-                .await
-                .unwrap();
-
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            }
+            tel_clone.write().await.run_telemetry().await;
         });
 
         loop {
@@ -310,6 +334,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
 
         let astarte_options = astarte_map_options(&options).await.unwrap();
@@ -331,9 +356,13 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
 
         let dm = DeviceManager::new(options, MockPublisher::new()).await;
+        if let Err(ref e) = dm {
+            println!("{:?}", e);
+        }
         assert!(dm.is_ok());
     }
 
@@ -349,6 +378,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
+            telemetry_config: vec![],
         };
 
         let os_info = get_os_info().unwrap();

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -20,6 +20,9 @@
 
 use astarte_sdk::{types::AstarteType, AstarteSdk};
 use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Notify;
 
@@ -32,21 +35,23 @@ pub(crate) mod system_info;
 pub(crate) mod system_status;
 pub(crate) mod wifi_scan;
 
-#[derive(Debug, Clone)]
+const TELEMETRY_PATH: &str = "telemetry.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryInterfaceConfig {
     pub interface_name: String,
     pub enabled: bool,
     pub period: u64,
 }
 pub struct Telemetry {
-    default_config: Arc<std::collections::HashMap<String, TelemetryInterfaceConfig>>,
+    default_config: Arc<HashMap<String, TelemetryInterfaceConfig>>,
     override_enabled: Arc<tokio::sync::RwLock<std::collections::HashMap<String, bool>>>,
     override_period: Arc<tokio::sync::RwLock<std::collections::HashMap<String, u64>>>,
     notify: std::collections::HashMap<String, Arc<Notify>>,
 }
 
 impl Telemetry {
-    pub fn from_default_config(cfg: Vec<TelemetryInterfaceConfig>) -> Self {
+    pub async fn from_default_config(cfg: Vec<TelemetryInterfaceConfig>) -> Self {
         let mut default_config = HashMap::new();
         let mut notify = HashMap::new();
 
@@ -58,12 +63,35 @@ impl Telemetry {
             notify.insert(name.clone(), not);
         }
 
-        Telemetry {
+        let ret = Telemetry {
             default_config: Arc::new(default_config),
             override_enabled: Default::default(),
             override_period: Default::default(),
             notify,
-        }
+        };
+
+        // Serde load configs from disk
+        if let Ok(file) = File::open(TELEMETRY_PATH) {
+            let saved_config: HashMap<String, TelemetryInterfaceConfig> =
+                serde_json::from_reader(BufReader::new(file)).unwrap();
+            let self_override_period = ret.override_period.clone();
+            let self_override_enabled = ret.override_enabled.clone();
+            for conf in saved_config.values() {
+                let name = conf.interface_name.clone();
+                *self_override_enabled
+                    .write()
+                    .await
+                    .entry(name.to_string())
+                    .or_insert(conf.enabled) = conf.enabled;
+                *self_override_period
+                    .write()
+                    .await
+                    .entry(name.to_string())
+                    .or_insert(conf.period) = conf.period;
+            }
+        };
+
+        ret
     }
 
     pub async fn run_telemetry(&self, sdk: AstarteSdk) {
@@ -122,12 +150,16 @@ impl Telemetry {
         if enabled {
             self.notify.get(interface_name).unwrap().notify_one();
         }
+
+        self.save_telemetry_config().await;
     }
 
     pub async fn unset_enabled(&self, interface_name: &str) {
         debug!("unset {interface_name} enabled");
 
         self.override_enabled.write().await.remove(interface_name);
+
+        self.save_telemetry_config().await;
     }
 
     pub async fn set_period(&self, interface_name: &str, period: u64) {
@@ -139,12 +171,16 @@ impl Telemetry {
             .await
             .entry(interface_name.to_string())
             .or_insert(period) = period;
+
+        self.save_telemetry_config().await;
     }
 
     pub async fn unset_period(&self, interface_name: &str) {
         debug!("unset {interface_name} period");
 
         self.override_period.write().await.remove(interface_name);
+
+        self.save_telemetry_config().await;
     }
 
     pub async fn telemetry_config_event(
@@ -166,7 +202,11 @@ impl Telemetry {
                 self.set_period(interface_name, *period as u64).await;
             }
 
-            ("PeriodSeconds", AstarteType::Unset) => {
+            ("periodSeconds", AstarteType::Integer(period)) => {
+                self.set_period(interface_name, *period as u64).await;
+            }
+
+            ("periodSeconds", AstarteType::Unset) => {
                 self.unset_period(interface_name).await;
             }
 
@@ -175,19 +215,124 @@ impl Telemetry {
             }
         }
     }
+
+    async fn save_telemetry_config(&self) {
+        let mut telemetry_config: HashMap<String, TelemetryInterfaceConfig> = HashMap::new();
+        for path in self.default_config.clone().keys() {
+            let interface_config = TelemetryInterfaceConfig {
+                interface_name: path.to_string(),
+                enabled: if let Some(enabled) = self.override_enabled.read().await.get(path) {
+                    enabled.clone()
+                } else {
+                    self.default_config.clone().get(path).unwrap().enabled
+                },
+                period: if let Some(period) = self.override_period.read().await.get(path) {
+                    period.clone()
+                } else {
+                    self.default_config.clone().get(path).unwrap().period
+                },
+            };
+            telemetry_config.insert(path.to_string(), interface_config);
+        }
+        let file = File::create(TELEMETRY_PATH).unwrap();
+        serde_json::to_writer(BufWriter::new(file), &telemetry_config).unwrap();
+    }
 }
 
 async fn send_data(sdk: &AstarteSdk, interface_name: String) {
     debug!("sending {interface_name}");
 
-    if interface_name.as_str() == "disable_io.edgehog.devicemanager.SystemStatus" {
+    if interface_name.as_str() == "io.edgehog.devicemanager.SystemStatus" {
         let sysstatus = system_status::get_system_status().unwrap();
         sdk.send_object(
             "io.edgehog.devicemanager.SystemStatus",
-            "/systemStatus/",
+            "/systemStatus",
             sysstatus,
         )
         .await
         .unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::telemetry::{Telemetry, TelemetryInterfaceConfig};
+
+    #[tokio::test]
+    async fn telemetry_default_test() {
+        let mut config = Vec::new();
+        let interface_name = "io.edgehog.devicemanager.SystemStatus";
+        config.push(TelemetryInterfaceConfig {
+            interface_name: interface_name.to_string(),
+            enabled: true,
+            period: 10,
+        });
+        let tel = Telemetry::from_default_config(config).await;
+        let telemetry_default = &*tel.default_config.clone();
+        let default_interface_config = telemetry_default.get(interface_name).unwrap();
+
+        assert_eq!(
+            default_interface_config.interface_name,
+            interface_name.to_string()
+        );
+        assert!(default_interface_config.enabled);
+        assert_eq!(default_interface_config.period, 10);
+    }
+
+    #[tokio::test]
+    async fn telemetry_set_test() {
+        let mut config = Vec::new();
+        let interface_name = "io.edgehog.devicemanager.SystemStatus";
+        config.push(TelemetryInterfaceConfig {
+            interface_name: interface_name.to_string(),
+            enabled: true,
+            period: 10,
+        });
+
+        let tel = Telemetry::from_default_config(config).await;
+
+        tel.set_enabled(&interface_name, false).await;
+        tel.set_period(&interface_name, 30).await;
+
+        assert!(!(*tel.override_enabled.clone())
+            .read()
+            .await
+            .get(interface_name)
+            .unwrap());
+        assert_eq!(
+            (*tel.override_period.clone())
+                .read()
+                .await
+                .get(interface_name)
+                .unwrap(),
+            &30
+        );
+    }
+
+    #[tokio::test]
+    async fn telemetry_unset_test() {
+        let mut config = Vec::new();
+        let interface_name = "io.edgehog.devicemanager.SystemStatus";
+        config.push(TelemetryInterfaceConfig {
+            interface_name: interface_name.to_string(),
+            enabled: true,
+            period: 10,
+        });
+
+        let tel = Telemetry::from_default_config(config).await;
+
+        tel.unset_enabled(&interface_name).await;
+        tel.unset_period(&interface_name).await;
+
+        assert!((*tel.override_enabled.clone())
+            .read()
+            .await
+            .get(interface_name)
+            .is_none());
+        assert!((*tel.override_period.clone())
+            .read()
+            .await
+            .get(interface_name)
+            .is_none());
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -18,6 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use astarte_sdk::{types::AstarteType, AstarteSdk};
+use log::{debug, warn};
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Notify;
+
 pub(crate) mod hardware_info;
 pub(crate) mod net_if_properties;
 pub(crate) mod os_info;
@@ -26,3 +31,163 @@ pub(crate) mod storage_usage;
 pub(crate) mod system_info;
 pub(crate) mod system_status;
 pub(crate) mod wifi_scan;
+
+#[derive(Debug, Clone)]
+pub struct TelemetryInterfaceConfig {
+    pub interface_name: String,
+    pub enabled: bool,
+    pub period: u64,
+}
+pub struct Telemetry {
+    default_config: Arc<std::collections::HashMap<String, TelemetryInterfaceConfig>>,
+    override_enabled: Arc<tokio::sync::RwLock<std::collections::HashMap<String, bool>>>,
+    override_period: Arc<tokio::sync::RwLock<std::collections::HashMap<String, u64>>>,
+    notify: std::collections::HashMap<String, Arc<Notify>>,
+}
+
+impl Telemetry {
+    pub fn from_default_config(cfg: Vec<TelemetryInterfaceConfig>) -> Self {
+        let mut default_config = HashMap::new();
+        let mut notify = HashMap::new();
+
+        for c in cfg {
+            let name = c.interface_name.clone();
+            default_config.insert(name.clone(), c);
+            let not = Arc::new(Notify::new());
+            not.notify_one();
+            notify.insert(name.clone(), not);
+        }
+
+        Telemetry {
+            default_config: Arc::new(default_config),
+            override_enabled: Default::default(),
+            override_period: Default::default(),
+            notify,
+        }
+    }
+
+    pub async fn run_telemetry(&self, sdk: AstarteSdk) {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+
+        for (interface_name, interface_cfg) in (*self.default_config).clone() {
+            let self_override_period = self.override_period.clone();
+            let self_override_enabled = self.override_enabled.clone();
+            let self_notify = self.notify.clone();
+
+            let txcl = tx.clone();
+
+            // task runs for every interface
+            tokio::task::spawn(async move {
+                loop {
+                    self_notify.get(&interface_name).unwrap().notified().await;
+
+                    let enabled = *self_override_enabled
+                        .read()
+                        .await
+                        .get(&interface_name)
+                        .unwrap_or(&interface_cfg.enabled);
+
+                    if enabled {
+                        self_notify.get(&interface_name).unwrap().notify_one();
+                    }
+
+                    txcl.send(interface_name.clone()).await.unwrap();
+
+                    let period = *self_override_period
+                        .read()
+                        .await
+                        .get(&interface_name)
+                        .unwrap_or(&interface_cfg.period);
+
+                    tokio::time::sleep(std::time::Duration::from_secs(period)).await;
+                }
+            });
+        }
+
+        while let Some(interface_name) = rx.recv().await {
+            send_data(&sdk, interface_name).await;
+        }
+    }
+
+    pub async fn set_enabled(&self, interface_name: &str, enabled: bool) {
+        debug!("set {interface_name} to enabled {enabled}");
+
+        *self
+            .override_enabled
+            .write()
+            .await
+            .entry(interface_name.to_string())
+            .or_insert(enabled) = enabled;
+
+        if enabled {
+            self.notify.get(interface_name).unwrap().notify_one();
+        }
+    }
+
+    pub async fn unset_enabled(&self, interface_name: &str) {
+        debug!("unset {interface_name} enabled");
+
+        self.override_enabled.write().await.remove(interface_name);
+    }
+
+    pub async fn set_period(&self, interface_name: &str, period: u64) {
+        debug!("set {interface_name} to period {period}");
+
+        *self
+            .override_period
+            .write()
+            .await
+            .entry(interface_name.to_string())
+            .or_insert(period) = period;
+    }
+
+    pub async fn unset_period(&self, interface_name: &str) {
+        debug!("unset {interface_name} period");
+
+        self.override_period.write().await.remove(interface_name);
+    }
+
+    pub async fn telemetry_config_event(
+        &self,
+        interface_name: &str,
+        endpoint: &str,
+        data: &AstarteType,
+    ) {
+        match (endpoint, data) {
+            ("enable", AstarteType::Boolean(enabled)) => {
+                self.set_enabled(interface_name, *enabled).await;
+            }
+
+            ("enable", AstarteType::Unset) => {
+                self.unset_enabled(interface_name).await;
+            }
+
+            ("periodSeconds", AstarteType::LongInteger(period)) => {
+                self.set_period(interface_name, *period as u64).await;
+            }
+
+            ("PeriodSeconds", AstarteType::Unset) => {
+                self.unset_period(interface_name).await;
+            }
+
+            _ => {
+                warn!("Received malformed data from io.edgehog.devicemanager.config.Telemetry: {endpoint} {data:?}");
+            }
+        }
+    }
+}
+
+async fn send_data(sdk: &AstarteSdk, interface_name: String) {
+    debug!("sending {interface_name}");
+
+    if interface_name.as_str() == "disable_io.edgehog.devicemanager.SystemStatus" {
+        let sysstatus = system_status::get_system_status().unwrap();
+        sdk.send_object(
+            "io.edgehog.devicemanager.SystemStatus",
+            "/systemStatus/",
+            sysstatus,
+        )
+        .await
+        .unwrap();
+    }
+}


### PR DESCRIPTION
- Add support to `io.edgehog.devicemanager.config.Telemetry`
- Add `telemetry_config` as an array of mappings in the `edgehog_config.toml` to represent the default telemetry configs.

Close #11 