### PR TITLE
Fix hardware-id-service dbus config file and use-dmi-serial handling

### DIFF
--- a/hardware-id-service/io.edgehog.Device.conf
+++ b/hardware-id-service/io.edgehog.Device.conf
@@ -1,10 +1,10 @@
-#  This file is part of Edgehog.
-#
-#  Copyright 2022 SECO Mind Srl
-#
-#  SPDX-License-Identifier: Apache-2.0
-
 <?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!--  This file is part of Edgehog.
+
+  Copyright 2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0 -->
 
 <!DOCTYPE busconfig PUBLIC
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"

--- a/hardware-id-service/src/main.rs
+++ b/hardware-id-service/src/main.rs
@@ -30,7 +30,7 @@ const DEFAULT_NAMESPACE: &str = "f79ad91f-c638-4889-ae74-9d001a3b4cf8";
 #[derive(Debug, Parser)]
 struct Cli {
     // Retrieve hardware id from file
-    #[clap(short, long, conflicts_with_all=&["use-dmi-serial ","kernel-cmdline-key"])]
+    #[clap(short, long, conflicts_with_all=&["use-dmi-serial","kernel-cmdline-key"])]
     file_path: Option<String>,
 
     // Shortcut per file-path = "/sys/class/dmi/id/board_serial"
@@ -38,7 +38,7 @@ struct Cli {
     use_dmi_serial : bool,
 
     // Retrieve hardware id from Kernel parameters in the form key=value
-    #[clap(short, long, conflicts_with_all=&["use-dmi-serial ","file-path"])]
+    #[clap(short, long, conflicts_with_all=&["use-dmi-serial","file-path"])]
     kernel_cmdline_key: Option<String>,
 }
 


### PR DESCRIPTION
Copying the config onto `/etc/dbus-1/system.d/` with the current license comment makes it unreadable by dbus.
Change the comment to be XML compliant.
Remove extra space in a parameter name.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>