### PR TITLE
Remove single file storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1418,11 +1418,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1956,13 +1956,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2192,6 +2192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,12 +2211,6 @@ name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = "0.11.11"
 toml = "0.5.9"
 uuid = {version="0.8.2", features = ["v5", "v4"] }
 systemd = { version = "0.10", optional = true }
-async-trait = "0.1.53"
+async-trait = "0.1.56"
 
 [dev-dependencies]
 mockall = "0.11.1"

--- a/src/ota/ota_handler.rs
+++ b/src/ota/ota_handler.rs
@@ -91,9 +91,10 @@ impl<'a> OTAHandler<'a> {
 
         Ok(OTAHandler {
             ota: Box::new(ota),
-            state_repository: Box::new(FileStateRepository {
-                path: opts.state_file.clone(),
-            }),
+            state_repository: Box::new(FileStateRepository::new(
+                opts.store_directory.clone(),
+                "state.json".to_owned(),
+            )),
             download_file_path: opts.download_directory.clone(),
         })
     }

--- a/src/repository/file_state_repository.rs
+++ b/src/repository/file_state_repository.rs
@@ -26,6 +26,17 @@ pub struct FileStateRepository {
     pub path: String,
 }
 
+impl FileStateRepository {
+    pub fn new(path: String, name: String) -> Self {
+        let path = if path.ends_with("/") {
+            path + &name
+        } else {
+            path + "/" + &name
+        };
+        FileStateRepository { path }
+    }
+}
+
 impl<T> StateRepository<T> for FileStateRepository
 where
     T: Serialize + DeserializeOwned + Send + Sync,
@@ -68,5 +79,19 @@ mod tests {
         assert!(repository.exists());
         assert_eq!(repository.read().unwrap(), value);
         repository.clear().unwrap();
+    }
+
+    #[test]
+    fn file_repository_new_end_without_slash() {
+        let file = FileStateRepository::new("/tmp/path".to_owned(), "state.json".to_owned());
+
+        assert_eq!(file.path, "/tmp/path/state.json".to_owned())
+    }
+
+    #[test]
+    fn file_repository_new_end_with_slash() {
+        let file = FileStateRepository::new("/tmp/path/".to_owned(), "state.json".to_owned());
+
+        assert_eq!(file.path, "/tmp/path/state.json".to_owned())
     }
 }


### PR DESCRIPTION
- Introduce a directory for data storage so that all data are confined to the same location and do not have files scattered throughout the system.
- Check configured path before device-runtime starts.
- Add some tests on get_credentials function.
