### PR TITLE
RAUC mark slot as good

### DIFF
--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -37,4 +37,10 @@ pub trait OTA: Send + Sync {
     async fn compatible(&self) -> Result<String, DeviceManagerError>;
     async fn boot_slot(&self) -> Result<String, DeviceManagerError>;
     async fn receive_completed(&self) -> Result<i32, DeviceManagerError>;
+    async fn get_primary(&self) -> Result<String, DeviceManagerError>;
+    async fn mark(
+        &self,
+        state: &str,
+        slot_identifier: &str,
+    ) -> Result<(String, String), DeviceManagerError>;
 }

--- a/src/ota/rauc.rs
+++ b/src/ota/rauc.rs
@@ -182,6 +182,24 @@ impl<'a> OTA for OTARauc<'a> {
             ))
         }
     }
+
+    async fn get_primary(&self) -> Result<String, DeviceManagerError> {
+        self.rauc
+            .get_primary()
+            .await
+            .map_err(|err| DeviceManagerError::ZbusError(err))
+    }
+
+    async fn mark(
+        &self,
+        state: &str,
+        slot_identifier: &str,
+    ) -> Result<(String, String), DeviceManagerError> {
+        self.rauc
+            .mark(state, slot_identifier)
+            .await
+            .map_err(|err| DeviceManagerError::ZbusError(err))
+    }
 }
 
 impl<'a> OTARauc<'a> {


### PR DESCRIPTION
Normally, the full system update chain is not complete before being sure that the newly installed system runs without any errors.
As the definition and detection of a successful operation is really  system-dependent, so we need to inform the bootloader that the slot selected by it was good.