### PR TITLE
Disable Warning annotations on test builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,5 +73,7 @@ jobs:
           override: true
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -Awarnings
         with:
           command: test


### PR DESCRIPTION
Sometimes test builds return some `unused import` or `unused variable` warning because some code parts are not used or mocked during tests.
These warnings are then reported as annotations in the `Files changed` tab disturbing the review process.
The Rust flag `-Awarning` suppresses this behavior during `cargo test`.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>