### PR TITLE
Add Backoff retry policy for retrying Astarte init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "astarte_sdk"
 version = "0.1.0"
-source = "git+https://github.com/astarte-platform/astarte-device-sdk-rust.git#908817e15e2149d21bb607fcdfefe736a53bc06b"
+source = "git+https://github.com/astarte-platform/astarte-device-sdk-rust.git#7ceea016693873628a7d81bdf03de005084d7e85"
 dependencies = [
  "async-trait",
  "base64",


### PR DESCRIPTION
Add simple backoff retry policy for retrying Astarte initialization,it based on pow of 2, the retry interval is incremental for max of 9 times that is about 8,5 minutes, after that the retry is fixed to every 8,5 minutes.
