### PR TITLE
Use mockall only as dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
+checksum = "5641e476bbaf592a3939a7485fa079f427b4db21407d5ebfd5bba4e07a1f6f4c"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
+checksum = "262d56735932ee0240d515656e5a7667af3af2a5b0af4da558c4cff2b2aeb0c7"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,7 @@ reqwest = "0.11.11"
 toml = "0.5.9"
 uuid = {version="0.8.2", features = ["v5", "v4"] }
 systemd = { version = "0.10", optional = true }
-mockall = "0.11.0"
 async-trait = "0.1.53"
+
+[dev-dependencies]
+mockall = "0.11.1"

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -20,11 +20,12 @@
 
 use astarte_sdk::AstarteError;
 use async_trait::async_trait;
+#[cfg(test)]
 use mockall::automock;
 
 pub(crate) mod astarte;
 
-#[automock]
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait Publisher: Send + Sync {
     async fn send_object<T: 'static>(

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -19,6 +19,7 @@
  */
 
 use async_trait::async_trait;
+#[cfg(test)]
 use mockall::automock;
 
 use crate::error::DeviceManagerError;
@@ -27,7 +28,7 @@ use crate::ota::rauc::BundleInfo;
 pub(crate) mod ota_handler;
 pub(crate) mod rauc;
 
-#[automock]
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait OTA: Send + Sync {
     async fn install_bundle(&self, source: &str) -> Result<(), DeviceManagerError>;

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -18,13 +18,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#[cfg(test)]
 use mockall::automock;
 
 use crate::error::DeviceManagerError;
 
 pub(crate) mod file_state_repository;
 
-#[automock]
+#[cfg_attr(test, automock)]
 pub trait StateRepository<T: Send + Sync>: Send + Sync {
     fn write(&self, value: &T) -> Result<(), DeviceManagerError>;
     fn read(&self) -> Result<T, DeviceManagerError>;


### PR DESCRIPTION
Typically mockall is only used by unit tests.