### PR TITLE
Specify default-run binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "edgehog-device-runtime"
 version = "0.1.0"
 edition = "2021"
 homepage = "https://github.com/edgehog-device-manager/edgehog-device-runtime"
+default-run = "edgehog-device-runtime"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ device_id = "YOUR_UNIQUE_DEVIDE_ID"
 pairing_url = "https://api.astarte.EXAMPLE.COM/pairing"
 realm = "examplerealm"
 interfaces_directory = "/usr/share/edgehog/astarte-interfaces/"
-state_file = "/var/lib/edgehog/state.json"
+store_directory = "/var/lib/edgehog/"
 download_directory = "/var/tmp/edgehog-updates/"
 ```
 


### PR DESCRIPTION
- Since the binary of `e2e-test` has been added, it should also be added which is the default binary, otherwise `cargo run` could not determine which binary to run.

- Update example configuration.