### PR TITLE
Device Manager new function refactoring

### DIFF
--- a/src/data/astarte.rs
+++ b/src/data/astarte.rs
@@ -19,11 +19,16 @@
  */
 
 use astarte_sdk::builder::AstarteOptions;
-use astarte_sdk::{AstarteError, AstarteSdk};
+use astarte_sdk::types::AstarteType;
+use astarte_sdk::{registration, AstarteError, AstarteSdk, Clientbound};
 use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::data::Publisher;
+use crate::error::DeviceManagerError;
+use crate::repository::file_state_repository::FileStateRepository;
+use crate::repository::StateRepository;
+use crate::{get_hardware_id_from_dbus, DeviceManagerOptions};
 
 #[derive(Clone)]
 pub struct Astarte {
@@ -45,11 +50,243 @@ impl Publisher for Astarte {
             .send_object(interface_name, interface_path, data)
             .await
     }
+
+    async fn send(
+        &self,
+        interface_name: &str,
+        interface_path: &str,
+        data: AstarteType,
+    ) -> Result<(), AstarteError> {
+        self.device_sdk
+            .send(interface_name, interface_path, data)
+            .await
+    }
+
+    async fn on_event(&mut self) -> Result<Clientbound, AstarteError> {
+        self.device_sdk.poll().await
+    }
 }
 
 impl Astarte {
-    pub async fn new(opts: &AstarteOptions) -> Result<Astarte, AstarteError> {
-        let device = AstarteSdk::new(&opts).await?;
+    pub async fn new(sdk_options: AstarteOptions) -> Result<Astarte, DeviceManagerError> {
+        let device = AstarteSdk::new(&sdk_options).await?;
         Ok(Astarte { device_sdk: device })
+    }
+}
+
+pub async fn astarte_map_options(
+    opts: &DeviceManagerOptions,
+) -> Result<AstarteOptions, DeviceManagerError> {
+    let device_id: String = get_device_id(opts.device_id.clone()).await?;
+    let store_directory = opts.store_directory.to_owned();
+    let credentials_secret: String = get_credentials_secret(
+        &device_id,
+        &opts,
+        FileStateRepository::new(store_directory, format!("credentials_{}.json", device_id)),
+    )
+    .await?;
+
+    let mut sdk_options = AstarteOptions::new(
+        &opts.realm,
+        &device_id,
+        &credentials_secret,
+        &opts.pairing_url,
+    );
+
+    if Some(true) == opts.astarte_ignore_ssl {
+        sdk_options.ignore_ssl_errors();
+    }
+
+    Ok(sdk_options
+        .interface_directory(&opts.interfaces_directory)?
+        .build())
+}
+
+async fn get_device_id(opt_device_id: Option<String>) -> Result<String, DeviceManagerError> {
+    if let Some(device_id) = opt_device_id {
+        Ok(device_id)
+    } else {
+        get_hardware_id_from_dbus().await
+    }
+}
+
+async fn get_credentials_secret(
+    device_id: &str,
+    opts: &DeviceManagerOptions,
+    cred_state_repo: impl StateRepository<String>,
+) -> Result<String, DeviceManagerError> {
+    if let Some(secret) = opts.credentials_secret.clone() {
+        Ok(secret)
+    } else if cred_state_repo.exists() {
+        get_credentials_secret_from_persistence(cred_state_repo)
+    } else if let Some(token) = opts.pairing_token.clone() {
+        get_credentials_secret_from_registration(device_id, &token, opts, cred_state_repo).await
+    } else {
+        Err(DeviceManagerError::FatalError(
+            "Missing arguments".to_string(),
+        ))
+    }
+}
+
+fn get_credentials_secret_from_persistence(
+    cred_state_repo: impl StateRepository<String>,
+) -> Result<String, DeviceManagerError> {
+    Ok(cred_state_repo.read().expect("Unable to read secret"))
+}
+
+async fn get_credentials_secret_from_registration(
+    device_id: &str,
+    token: &str,
+    opts: &DeviceManagerOptions,
+    cred_state_repo: impl StateRepository<String>,
+) -> Result<String, DeviceManagerError> {
+    let registration =
+        registration::register_device(token, &opts.pairing_url, &opts.realm, &device_id).await;
+    if let Ok(credentials_secret) = registration {
+        cred_state_repo
+            .write(&credentials_secret)
+            .expect("Unable to write secret");
+        Ok(credentials_secret)
+    } else {
+        Err(DeviceManagerError::FatalError("Pairing error".to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repository::MockStateRepository;
+    use crate::{DeviceManagerError, DeviceManagerOptions};
+
+    use crate::data::astarte::{
+        get_credentials_secret, get_credentials_secret_from_registration, get_device_id,
+    };
+
+    #[tokio::test]
+    async fn device_id_test() {
+        assert_eq!(
+            get_device_id(Some("target".to_string())).await.unwrap(),
+            "target".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn credentials_secret_test() {
+        let state_mock = MockStateRepository::<String>::new();
+        let options = DeviceManagerOptions {
+            realm: "".to_string(),
+            device_id: None,
+            credentials_secret: Some("credentials_secret".to_string()),
+            pairing_url: "".to_string(),
+            pairing_token: None,
+            interfaces_directory: "".to_string(),
+            store_directory: "".to_string(),
+            download_directory: "".to_string(),
+            astarte_ignore_ssl: Some(false),
+        };
+        assert_eq!(
+            get_credentials_secret("device_id", &options, state_mock)
+                .await
+                .unwrap(),
+            "credentials_secret".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn not_enough_arguments_credentials_secret_test() {
+        let mut state_mock = MockStateRepository::<String>::new();
+        state_mock.expect_exists().returning(|| false);
+        let options = DeviceManagerOptions {
+            realm: "".to_string(),
+            device_id: None,
+            credentials_secret: None,
+            pairing_url: "".to_string(),
+            pairing_token: None,
+            interfaces_directory: "".to_string(),
+            store_directory: "".to_string(),
+            download_directory: "".to_string(),
+            astarte_ignore_ssl: Some(false),
+        };
+        assert!(get_credentials_secret("device_id", &options, state_mock)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Unable to read secret: FatalError(\"\")")]
+    async fn get_credentials_secret_persistence_fail() {
+        let mut state_mock = MockStateRepository::<String>::new();
+        state_mock.expect_exists().returning(|| true);
+        state_mock
+            .expect_read()
+            .returning(move || Err(DeviceManagerError::FatalError("".to_owned())));
+
+        let options = DeviceManagerOptions {
+            realm: "".to_string(),
+            device_id: Some("device_id".to_owned()),
+            credentials_secret: None,
+            pairing_url: "".to_string(),
+            pairing_token: None,
+            interfaces_directory: "".to_string(),
+            store_directory: "".to_string(),
+            download_directory: "".to_string(),
+            astarte_ignore_ssl: Some(false),
+        };
+
+        assert!(get_credentials_secret("device_id", &options, state_mock)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn get_credentials_secret_persistence_success() {
+        let mut state_mock = MockStateRepository::<String>::new();
+        state_mock.expect_exists().returning(|| true);
+        state_mock
+            .expect_read()
+            .returning(move || Ok("cred_secret".to_owned()));
+
+        let options = DeviceManagerOptions {
+            realm: "".to_string(),
+            device_id: Some("device_id".to_owned()),
+            credentials_secret: None,
+            pairing_url: "".to_string(),
+            pairing_token: None,
+            interfaces_directory: "".to_string(),
+            store_directory: "".to_string(),
+            download_directory: "".to_string(),
+            astarte_ignore_ssl: Some(false),
+        };
+
+        assert!(get_credentials_secret("device_id", &options, state_mock)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn get_credentials_secret_from_registration_fail() {
+        let options = DeviceManagerOptions {
+            realm: "".to_string(),
+            device_id: Some("device_id".to_owned()),
+            credentials_secret: Some("credentials_secret".to_string()),
+            pairing_url: "".to_string(),
+            pairing_token: None,
+            interfaces_directory: "./".to_string(),
+            store_directory: "".to_string(),
+            download_directory: "".to_string(),
+            astarte_ignore_ssl: Some(false),
+        };
+
+        let state_mock = MockStateRepository::<String>::new();
+        let cred_result =
+            get_credentials_secret_from_registration("", "", &options, state_mock).await;
+        assert!(cred_result.is_err());
+        match cred_result.err().unwrap() {
+            DeviceManagerError::FatalError(val) => {
+                assert_eq!(val, "Pairing error".to_owned())
+            }
+            _ => {
+                panic!("Wrong DeviceManagerError type");
+            }
+        };
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -18,12 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_sdk::AstarteError;
+use astarte_sdk::types::AstarteType;
+use astarte_sdk::{AstarteError, Clientbound};
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall::automock;
 
-pub(crate) mod astarte;
+pub mod astarte;
 
 #[cfg_attr(test, automock)]
 #[async_trait]
@@ -36,5 +37,13 @@ pub trait Publisher: Send + Sync {
     ) -> Result<(), AstarteError>
     where
         T: serde::Serialize + Send;
-    //TODO add send and send_object_with_timestamp to this trait
+    //TODO add send_object_with_timestamp to this trait
+    async fn send(
+        &self,
+        interface_name: &str,
+        interface_path: &str,
+        data: AstarteType,
+    ) -> Result<(), AstarteError>;
+
+    async fn on_event(&mut self) -> Result<Clientbound, AstarteError>;
 }

--- a/src/e2e_test/e2e_test.rs
+++ b/src/e2e_test/e2e_test.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::panic;
 
+use edgehog_device_runtime::data::astarte::{astarte_map_options, Astarte};
 use edgehog_device_runtime::e2e_test::{get_hardware_info, get_os_info, get_runtime_info};
 use edgehog_device_runtime::{DeviceManager, DeviceManagerOptions};
 
@@ -62,7 +63,9 @@ async fn main() -> Result<(), edgehog_device_runtime::error::DeviceManagerError>
         astarte_ignore_ssl: Some(false),
     };
 
-    let mut dm = DeviceManager::new(device_options).await?;
+    let astarte_options = astarte_map_options(&device_options).await?;
+    let astarte = Astarte::new(astarte_options).await?;
+    let mut dm = DeviceManager::new(device_options, astarte).await?;
 
     dm.init().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::panic::{self, PanicInfo};
 use std::path::Path;
 
 use config::read_options;
+use edgehog_device_runtime::data::astarte::{astarte_map_options, Astarte};
 use edgehog_device_runtime::error::DeviceManagerError;
 
 mod config;
@@ -73,7 +74,9 @@ async fn main() -> Result<(), DeviceManagerError> {
         })?;
     }
 
-    let mut dm = edgehog_device_runtime::DeviceManager::new(options).await?;
+    let astarte_options = astarte_map_options(&options).await?;
+    let astarte = Astarte::new(astarte_options).await?;
+    let mut dm = edgehog_device_runtime::DeviceManager::new(options, astarte).await?;
 
     dm.init().await?;
 


### PR DESCRIPTION
- Avoid blocking main loop, all data received from Astarte will be passed through a channel.
- For the OTA event, we use a dedicated channel with buffer capacity equal to 1 because it can only receive one OTA event at a time.
-  Inject Astarte Device as dependecy to the DeviceManager.
- Use Publisher trait on DeviceManager struct is useful both for not depending directly on the SDK and for testing reasons.
- Move Astarte stuffs in data module.
- Add tests

