### PR TITLE
Use consts::ARCH for reading the architecture of the CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,6 @@ dependencies = [
  "env_logger",
  "log",
  "mockall",
- "nix",
  "procfs",
  "reqwest",
  "rustc_version_runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ default-run = "edgehog-device-runtime"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nix = "0.23.1"
 thiserror = "1.0.31"
 astarte_sdk = {git ="https://github.com/astarte-platform/astarte-device-sdk-rust.git" }
 log = "0.4"

--- a/src/telemetry/hardware_info.rs
+++ b/src/telemetry/hardware_info.rs
@@ -59,7 +59,7 @@ fn get_cpu_info() -> ProcResult<CpuInfo> {
 
 #[cfg(not(test))]
 fn get_machine_architecture() -> String {
-    nix::sys::utsname::uname().machine().to_owned()
+    std::env::consts::ARCH.to_owned()
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
- Use `std::env::consts::ARCH` for reading the architecture of the CPU
- Remove `nix` crate dependency
