### PR TITLE
Add support to WiFiScanResults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "chrono",
  "flate2",
  "http",
- "itertools",
+ "itertools 0.10.3",
  "log",
  "openssl",
  "reqwest",
@@ -502,6 +502,7 @@ dependencies = [
  "toml",
  "udev",
  "uuid",
+ "wifiscanner",
  "zbus",
 ]
 
@@ -973,6 +974,15 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
@@ -1440,7 +1450,7 @@ checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.3",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -1998,7 +2008,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
 dependencies = [
- "itertools",
+ "itertools 0.10.3",
  "nom",
  "unicode_categories",
 ]
@@ -2619,6 +2629,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "wifiscanner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74e667d34abc74f1e5b509ae3d24641f56514ba2c5a64f9d733ae2061aef856"
+dependencies = [
+ "itertools 0.8.2",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ systemd = { version = "0.10", optional = true }
 async-trait = "0.1.56"
 sysinfo = "0.24.6"
 udev = "0.6.3"
+wifiscanner = "0.5.*"
 
 [dev-dependencies]
 mockall = "0.11.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,4 +54,7 @@ pub enum DeviceManagerError {
 
     #[error("configuration file error")]
     ConfigFileError(#[from] toml::de::Error),
+
+    #[error("integer parse error")]
+    ParseIntError(#[from] std::num::ParseIntError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,17 @@ impl<T: Publisher + Clone + 'static> DeviceManager<T> {
                 )
                 .await?;
         }
+
+        for wifi_scan_result in telemetry::wifi_scan::get_wifi_scan_results()? {
+            device
+                .send_object(
+                    "io.edgehog.devicemanager.WiFiScanResults",
+                    "/ap",
+                    wifi_scan_result,
+                )
+                .await?;
+        }
+
         Ok(())
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -25,3 +25,4 @@ pub(crate) mod runtime_info;
 pub(crate) mod storage_usage;
 pub(crate) mod system_info;
 pub(crate) mod system_status;
+pub(crate) mod wifi_scan;

--- a/src/telemetry/wifi_scan.rs
+++ b/src/telemetry/wifi_scan.rs
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::DeviceManagerError;
+use serde::Serialize;
+use wifiscanner;
+use wifiscanner::Wifi;
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WifiScanResult {
+    channel: i32,
+    connected: bool,
+    essid: String,
+    mac_address: String,
+    rssi: i32,
+}
+
+pub fn get_wifi_scan_results() -> Result<Vec<WifiScanResult>, DeviceManagerError> {
+    let mut ret = Vec::new();
+    if let Ok(wifi_array) = wifiscanner::scan() {
+        for wifi in wifi_array {
+            let w = wifi.try_into()?;
+            ret.push(w);
+        }
+    }
+
+    Ok(ret)
+}
+
+impl TryFrom<Wifi> for WifiScanResult {
+    type Error = DeviceManagerError;
+    fn try_from(wifi: Wifi) -> Result<Self, Self::Error> {
+        Ok(WifiScanResult {
+            channel: wifi.channel.parse::<i32>()?,
+            connected: false,
+            essid: wifi.ssid.into(),
+            mac_address: wifi.mac.into(),
+            rssi: wifi.signal_level.parse::<i32>()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::telemetry::wifi_scan::{get_wifi_scan_results, WifiScanResult};
+    use wifiscanner::Wifi;
+
+    #[test]
+    fn wifi_scan_test() {
+        assert!(get_wifi_scan_results().is_ok());
+    }
+
+    #[test]
+    fn get_hashmap_from_wifi_test() {
+        let wifi = Wifi {
+            mac: "ab:cd:ef:01:23:45".to_string(),
+            ssid: "Vodafone Hotspot".to_string(),
+            channel: "6".to_string(),
+            signal_level: "-92".to_string(),
+            security: "Open".to_string(),
+        };
+        let inter: Result<WifiScanResult, _> = wifi.try_into();
+        assert!(inter.is_ok());
+        assert_eq!(
+            inter.unwrap(),
+            WifiScanResult {
+                channel: 6,
+                connected: false,
+                essid: "Vodafone Hotspot".to_string(),
+                mac_address: "ab:cd:ef:01:23:45".to_string(),
+                rssi: -92
+            }
+        );
+    }
+}


### PR DESCRIPTION
Add the Wi-Fi scan functionality using `iw` on Linux via the
`wifiscanner` rust crate.

Close #24 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>