### PR TITLE
Implement io.edgehog.devicemanager.BatteryStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following information are sent to remote Edgehog instance:
 - `Edgehog Device Runtime` status changes via systemd.
 - Network interface info
 - Base image (data is read from `/etc/os-release`)
+- Battery status data
 
 ## How it Works
 

--- a/doc/os_requirements.md
+++ b/doc/os_requirements.md
@@ -18,6 +18,7 @@ Edgehog Device Runtime has a number of requirements in order to provide device m
 ### Runtime Dependencies
 * **[dbus](https://www.freedesktop.org/wiki/Software/dbus/)** (optional): Needed for communicating with 3rd party services, such as RAUC.
 * **[RAUC](https://rauc.io/) ~> v1.5** (optional): Needed for OS updates.
+* **[UPower](https://upower.freedesktop.org/)**: (optional) Needed to gather information about the battery status.
 
 ### Filesystem Layout
 * **/tmp**: Software updates will be downloaded here.

--- a/src/telemetry/battery_status.rs
+++ b/src/telemetry/battery_status.rs
@@ -1,0 +1,244 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use serde::Serialize;
+use std::collections::HashMap;
+
+use crate::error::DeviceManagerError;
+use crate::telemetry::upower::device::{BatteryState, DeviceProxy, PowerDeviceType};
+use crate::telemetry::upower::upower::UPowerProxy;
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BatteryStatus {
+    level_percentage: f64,
+    level_absolute_error: f64,
+    /// "Battery status string, any of: Charging, Discharging, Idle, EitherIdleOrCharging, Failure, Removed, Unknown",
+    status: String,
+}
+
+impl BatteryStatus {
+    pub async fn new(level_percentage: f64, device_state: BatteryState, is_present: bool) -> Self {
+        let status = get_status(device_state, is_present);
+        let level_absolute_error = get_error_level(device_state);
+
+        BatteryStatus {
+            level_percentage,
+            level_absolute_error,
+            status,
+        }
+    }
+}
+
+pub async fn get_battery_status() -> Result<HashMap<String, BatteryStatus>, DeviceManagerError> {
+    let connection = match zbus::Connection::system().await {
+        Ok(con) => con,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let upower = match UPowerProxy::new(&connection).await {
+        Ok(proxy) => proxy,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let devices = match upower.enumerate_devices().await {
+        Ok(devices) => devices,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let mut result = HashMap::new();
+    for device_path in devices {
+        let device = DeviceProxy::builder(&connection)
+            .path(device_path)?
+            .build()
+            .await?;
+
+        if device.power_device_type().await? == PowerDeviceType::Battery {
+            result.insert(
+                device.serial().await?,
+                BatteryStatus::new(
+                    device.percentage().await.unwrap(),
+                    device.state().await?,
+                    device.is_present().await?,
+                )
+                .await,
+            );
+        }
+    }
+    Ok(result)
+}
+
+fn get_status(device_state: BatteryState, is_present: bool) -> String {
+    match device_state {
+        BatteryState::Charging => "Charging".to_string(),
+        BatteryState::Discharging => "Discharging".to_string(),
+        BatteryState::Unknown => "Unknown".to_string(),
+        _ => {
+            if is_present {
+                "Idle".to_string()
+            } else {
+                "Removed".to_string()
+            }
+        }
+    }
+}
+
+fn get_error_level(device_state: BatteryState) -> f64 {
+    if device_state == BatteryState::Unknown {
+        100 as f64
+    } else {
+        0 as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::telemetry::battery_status::{
+        get_battery_status, get_error_level, get_status, BatteryStatus,
+    };
+    use crate::telemetry::upower::device::BatteryState;
+
+    #[tokio::test]
+    async fn battery_unknown_new_test() {
+        let level_percentage: f64 = 100.0;
+        let device_state = BatteryState::Unknown;
+        let is_present = true;
+
+        let battery = BatteryStatus::new(level_percentage, device_state, is_present).await;
+
+        assert_eq!(
+            battery,
+            BatteryStatus {
+                level_percentage,
+                level_absolute_error: 100.0,
+                status: "Unknown".to_string()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn battery_charging_new_test() {
+        let level_percentage: f64 = 100.0;
+        let device_state = BatteryState::Charging;
+        let is_present = true;
+
+        let battery = BatteryStatus::new(level_percentage, device_state, is_present).await;
+
+        assert_eq!(
+            battery,
+            BatteryStatus {
+                level_percentage,
+                level_absolute_error: 0.0,
+                status: "Charging".to_string()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn battery_discharging_new_test() {
+        let level_percentage: f64 = 50.0;
+        let device_state = BatteryState::Discharging;
+        let is_present = true;
+
+        let battery = BatteryStatus::new(level_percentage, device_state, is_present).await;
+
+        assert_eq!(
+            battery,
+            BatteryStatus {
+                level_percentage,
+                level_absolute_error: 0.0,
+                status: "Discharging".to_string()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn battery_idle_new_test() {
+        let level_percentage: f64 = 100.0;
+        let device_state = BatteryState::FullyCharged;
+        let is_present = true;
+
+        let battery = BatteryStatus::new(level_percentage, device_state, is_present).await;
+
+        assert_eq!(
+            battery,
+            BatteryStatus {
+                level_percentage,
+                level_absolute_error: 0.0,
+                status: "Idle".to_string()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn battery_removed_new_test() {
+        let level_percentage: f64 = 100.0;
+        let device_state = BatteryState::FullyCharged;
+        let is_present = false;
+
+        let battery = BatteryStatus::new(level_percentage, device_state, is_present).await;
+
+        assert_eq!(
+            battery,
+            BatteryStatus {
+                level_percentage,
+                level_absolute_error: 0.0,
+                status: "Removed".to_string()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn get_battery_status_test() {
+        let battery_status_result = get_battery_status().await;
+        println!("{:?}", battery_status_result);
+        assert!(battery_status_result.is_ok());
+    }
+
+    #[test]
+    fn get_status_test() {
+        assert_eq!(
+            get_status(BatteryState::Charging, true),
+            "Charging".to_string()
+        );
+        assert_eq!(
+            get_status(BatteryState::Discharging, true),
+            "Discharging".to_string()
+        );
+        assert_eq!(
+            get_status(BatteryState::Unknown, true),
+            "Unknown".to_string()
+        );
+        assert_eq!(
+            get_status(BatteryState::FullyCharged, true),
+            "Idle".to_string()
+        );
+        assert_eq!(
+            get_status(BatteryState::Empty, false),
+            "Removed".to_string()
+        );
+    }
+
+    #[test]
+    fn get_error_level_test() {
+        assert_eq!(get_error_level(BatteryState::Charging), 0 as f64);
+        assert_eq!(get_error_level(BatteryState::Unknown), 100 as f64);
+    }
+}

--- a/src/telemetry/upower/device.rs
+++ b/src/telemetry/upower/device.rs
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use zbus::dbus_proxy;
+use zbus::zvariant::OwnedValue;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, OwnedValue)]
+#[repr(u32)]
+pub enum BatteryState {
+    Unknown = 0,
+    Charging = 1,
+    Discharging = 2,
+    Empty = 3,
+    FullyCharged = 4,
+    PendingCharge = 5,
+    PendingDischarge = 6,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, OwnedValue)]
+#[repr(u32)]
+pub enum PowerDeviceType {
+    Unknown = 0,
+    LinePower = 1,
+    Battery = 2,
+    Ups = 3,
+    Monitor = 4,
+    Mouse = 5,
+    Keyboard = 6,
+    Pda = 7,
+    Phone = 8,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, OwnedValue)]
+#[repr(u32)]
+pub enum BatteryLevel {
+    Unknown = 0,
+    None = 1,
+    Low = 3,
+    Critical = 4,
+    Normal = 5,
+    High = 7,
+    Full = 8,
+}
+
+#[dbus_proxy(
+    interface = "org.freedesktop.UPower.Device",
+    default_service = "org.freedesktop.UPower"
+)]
+trait Device {
+    /// The level of the battery for devices which do not report a percentage but rather a coarse battery level.
+    /// If the value is None, then the device does not support coarse battery reporting, and the percentage should be used instead.
+    #[dbus_proxy(property)]
+    fn battery_level(&self) -> zbus::Result<BatteryLevel>;
+
+    ///If the power source is present in the bay. This field is required as some batteries are hot-removable, for example expensive UPS and most laptop batteries.
+    //
+    // This property is only valid if the property type has the value "battery".
+    #[dbus_proxy(property)]
+    fn is_present(&self) -> zbus::Result<bool>;
+
+    /// The amount of energy left in the power source expressed as a percentage between 0 and 100.
+    /// Typically this is the same as (energy - energy-empty) / (energy-full - energy-empty).
+    /// However, some primitive power sources are capable of only reporting percentages and in this case the energy-* properties will be unset while this property is set.
+    //
+    // This property is only valid if the property type has the value "battery".
+    //
+    // The percentage will be an approximation if the battery level is set to something other than None.
+    #[dbus_proxy(property)]
+    fn percentage(&self) -> zbus::Result<f64>;
+
+    /// If the power device is used to supply the system. This would be set TRUE for laptop batteries and UPS devices, but set FALSE for wireless mice or PDAs.
+    #[dbus_proxy(property)]
+    fn power_supply(&self) -> zbus::Result<bool>;
+
+    /// Refreshes the data collected from the power source.
+    fn refresh(&self) -> zbus::Result<()>;
+
+    ///Unique serial number of the battery.
+    #[dbus_proxy(property)]
+    fn serial(&self) -> zbus::Result<String>;
+
+    /// The battery power state.
+    #[dbus_proxy(property)]
+    fn state(&self) -> zbus::Result<BatteryState>;
+
+    /// If the value is set to "Battery", you will need to verify that the property power-supply has the value "true" before considering it as a laptop battery.
+    /// Otherwise it will likely be the battery for a device of an unknown type.
+    #[dbus_proxy(property, name = "Type")]
+    fn power_device_type(&self) -> zbus::Result<PowerDeviceType>;
+}

--- a/src/telemetry/upower/mod.rs
+++ b/src/telemetry/upower/mod.rs
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pub(crate) mod device;
+pub(crate) mod upower;

--- a/src/telemetry/upower/upower.rs
+++ b/src/telemetry/upower/upower.rs
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use zbus::dbus_proxy;
+
+#[dbus_proxy(interface = "org.freedesktop.UPower")]
+trait UPower {
+    /// Enumerate all power objects on the system.
+    fn enumerate_devices(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
+
+    /// Indicates whether the system is running on battery power. This property is provided for convenience.
+    #[dbus_proxy(property)]
+    fn on_battery(&self) -> zbus::Result<bool>;
+}


### PR DESCRIPTION
Add support to `io.edgehog.devicemanager.BatteryStatus` interface
with data from UPower collected via D-Bus.

Close #16 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>