### PR TITLE
Add support to BaseImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following information are sent to remote Edgehog instance:
 - OTA update using RAUC
 - `Edgehog Device Runtime` status changes via systemd.
 - Network interface info
+- Base image (data is read from `/etc/os-release`)
 
 ## How it Works
 

--- a/doc/os_requirements.md
+++ b/doc/os_requirements.md
@@ -22,6 +22,8 @@ Edgehog Device Runtime has a number of requirements in order to provide device m
 ### Filesystem Layout
 * **/tmp**: Software updates will be downloaded here.
 * **/data**: Edgehog Device Runtime will store its state here during the OTA update process.
+* **[/etc/os-release](https://www.freedesktop.org/software/systemd/man/os-release.html)**: NAME,
+  VERSION_ID, BUILD_ID, IMAGE_ID, IMAGE_VERSION entries are used for OSInfo and BaseImage.
 
 ### Optional features
 * **systemd**: If `edgehog-device-runtime` is a `systemd` service, it can notify `systemd` of its status changes. This is provided via the `rust-systemd` crate, a Rust interface to `libsystemd/libelogind` APIs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,10 @@ impl<T: Publisher + Clone + 'static> DeviceManager<T> {
                 "io.edgehog.devicemanager.SystemInfo",
                 telemetry::system_info::get_system_info()?,
             ),
+            (
+                "io.edgehog.devicemanager.BaseImage",
+                telemetry::base_image::get_base_image()?,
+            ),
         ];
 
         for (ifc, fields) in data {
@@ -304,6 +308,7 @@ pub async fn get_hardware_id_from_dbus() -> Result<String, DeviceManagerError> {
 mod tests {
     use crate::data::astarte::{astarte_map_options, Astarte};
     use crate::data::MockPublisher;
+    use crate::telemetry::base_image::get_base_image;
     use crate::telemetry::hardware_info::get_hardware_info;
     use crate::telemetry::net_if_properties::get_network_interface_properties;
     use crate::telemetry::os_info::get_os_info;
@@ -444,6 +449,17 @@ mod tests {
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
                     interface_name == "io.edgehog.devicemanager.SystemInfo"
                         && system_info.get(interface_path).unwrap() == data
+                },
+            )
+            .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
+
+        let base_image = get_base_image().unwrap();
+        publisher
+            .expect_send()
+            .withf(
+                move |interface_name: &str, interface_path: &str, data: &AstarteType| {
+                    interface_name == "io.edgehog.devicemanager.BaseImage"
+                        && base_image.get(interface_path).unwrap() == data
                 },
             )
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));

--- a/src/telemetry/base_image.rs
+++ b/src/telemetry/base_image.rs
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::DeviceManagerError;
+use astarte_sdk::types::AstarteType;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+pub fn get_base_image() -> Result<HashMap<String, AstarteType>, DeviceManagerError> {
+    let file = BufReader::new(File::open("/etc/os-release")?);
+    Ok(file
+        .lines()
+        .flat_map(|line| line)
+        .fold(HashMap::new(), get_from_iter))
+}
+
+fn get_from_iter(
+    mut ret: HashMap<String, AstarteType>,
+    line: String,
+) -> HashMap<String, AstarteType> {
+    if let Some((key, value)) = line.trim().split_once('=') {
+        match key {
+            "IMAGE_ID" => {
+                let value = value.replace('"', "");
+                ret.insert("/name".to_string(), AstarteType::String(value));
+            }
+            "IMAGE_VERSION" => {
+                let value = value.replace('"', "");
+                if let Some((version, build_id)) = value.split_once('+') {
+                    ret.insert(
+                        "/version".to_string(),
+                        AstarteType::String(version.to_string()),
+                    );
+                    ret.insert(
+                        "/buildId".to_string(),
+                        AstarteType::String(build_id.to_string()),
+                    );
+                } else {
+                    ret.insert("/version".to_string(), AstarteType::String(value));
+                }
+            }
+            _ => {}
+        }
+    }
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::telemetry::base_image::{get_base_image, get_from_iter};
+    use astarte_sdk::types::AstarteType;
+    use std::collections::HashMap;
+
+    #[test]
+    fn get_base_image_test() {
+        let result = get_base_image();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn get_from_iter_empty_test() {
+        const OS_RELEASE: &str = r#"
+        NAME="Ubuntu"
+        VERSION="18.04.6 LTS (Bionic Beaver)"
+        ID=ubuntu
+        ID_LIKE=debian
+        PRETTY_NAME="Ubuntu 18.04.6 LTS"
+        VERSION_ID="18.04"
+        HOME_URL="https://www.ubuntu.com/"
+        SUPPORT_URL="https://help.ubuntu.com/"
+        BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+        PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+        VERSION_CODENAME=bionic
+        UBUNTU_CODENAME=bionic"#;
+
+        let map = OS_RELEASE
+            .lines()
+            .map(|x| x.into())
+            .fold(HashMap::new(), get_from_iter);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn get_from_iter_test() {
+        const OS_RELEASE: &str = r#"
+        NAME="Ubuntu"
+        VERSION="18.04.6 LTS (Bionic Beaver)"
+        ID=ubuntu
+        ID_LIKE=debian
+        PRETTY_NAME="Ubuntu 18.04.6 LTS"
+        VERSION_ID="18.04"
+        HOME_URL="https://www.ubuntu.com/"
+        SUPPORT_URL="https://help.ubuntu.com/"
+        BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+        PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+        VERSION_CODENAME=bionic
+        UBUNTU_CODENAME=bionic
+        IMAGE_ID="testOs"
+        IMAGE_VERSION="1.0.0+20220922""#;
+
+        let map = OS_RELEASE
+            .lines()
+            .map(|x| x.into())
+            .fold(HashMap::new(), get_from_iter);
+        assert!(!map.is_empty());
+        assert_eq!(
+            map.get("/name").unwrap(),
+            &AstarteType::String("testOs".to_string())
+        );
+        assert_eq!(
+            map.get("/version").unwrap(),
+            &AstarteType::String("1.0.0".to_string())
+        );
+        assert_eq!(
+            map.get("/buildId").unwrap(),
+            &AstarteType::String("20220922".to_string())
+        );
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -31,6 +31,7 @@ use tokio::sync::RwLock;
 use tokio::task::spawn;
 use tokio::time::interval;
 
+pub(crate) mod base_image;
 pub(crate) mod hardware_info;
 pub(crate) mod net_if_properties;
 pub(crate) mod os_info;


### PR DESCRIPTION
Add support retrieving `IMAGE_ID` AND `IMAGE_VERSION` from `/etc/os-release` for `io.edgehog.devicemanager.BaseImage`. 
Said data are optional and limited to supported OSs. 
`/name` is retrieved from `IMAGE_ID`;
`/version` is retrieved from the first half of `IMAGE_VERSION` splitted over the character `+`;
`/buildId` is retrieved from the first half of `IMAGE_VERSION` splitted over the character `+`;
`/fingerprint` is left for future releases and only for OSs supporting image hashing.

Close #6 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>