### PR TITLE
Make `telemetry_config` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ realm = "examplerealm"
 interfaces_directory = "/usr/share/edgehog/astarte-interfaces/"
 store_directory = "/var/lib/edgehog/"
 download_directory = "/var/tmp/edgehog-updates/"
+[[telemetry_config]]
+interface_name = "io.edgehog.devicemanager.SystemStatus"
+enabled = true
+period = 60
 ```
 
 ## Contributing

--- a/src/data/astarte.rs
+++ b/src/data/astarte.rs
@@ -182,7 +182,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
         assert_eq!(
             get_credentials_secret("device_id", &options, state_mock)
@@ -206,7 +206,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
         assert!(get_credentials_secret("device_id", &options, state_mock)
             .await
@@ -232,7 +232,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
 
         assert!(get_credentials_secret("device_id", &options, state_mock)
@@ -258,7 +258,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
 
         assert!(get_credentials_secret("device_id", &options, state_mock)
@@ -278,7 +278,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
 
         let state_mock = MockStateRepository::<String>::new();

--- a/src/e2e_test/e2e_test.rs
+++ b/src/e2e_test/e2e_test.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), edgehog_device_runtime::error::DeviceManagerError>
         store_directory: "".to_string(),
         download_directory: "".to_string(),
         astarte_ignore_ssl: Some(false),
-        telemetry_config: vec![],
+        telemetry_config: Some(vec![]),
     };
 
     let astarte_options = astarte_map_options(&device_options).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub struct DeviceManagerOptions {
     pub store_directory: String,
     pub download_directory: String,
     pub astarte_ignore_ssl: Option<bool>,
-    pub telemetry_config: Vec<telemetry::TelemetryInterfaceConfig>,
+    pub telemetry_config: Option<Vec<telemetry::TelemetryInterfaceConfig>>,
 }
 
 pub struct DeviceManager<T: Publisher + Clone> {
@@ -339,7 +339,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
 
         let astarte_options = astarte_map_options(&options).await.unwrap();
@@ -361,7 +361,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
 
         let dm = DeviceManager::new(options, MockPublisher::new()).await;
@@ -383,7 +383,7 @@ mod tests {
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
-            telemetry_config: vec![],
+            telemetry_config: Some(vec![]),
         };
 
         let os_info = get_os_info().unwrap();


### PR DESCRIPTION
Update `DeviceManagerOptions` to make `telemetry_config` optional. 
Update the README to show the `telemetry_config`setup.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>