### PR TITLE
Revert sysinfo to 0.26.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.59.0
+          - 1.58.1
     steps:
       - name: Install dependencies
         run: |
@@ -61,7 +61,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.59.0
+          - 1.58.1
     steps:
       - name: Install libudev
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ toml = "0.5.9"
 uuid = {version="0.8.2", features = ["v5", "v4"] }
 systemd = { version = "0.10", optional = true }
 async-trait = "0.1.57"
-sysinfo = "0.26.4"
+sysinfo = "0.26.2"
 udev = "0.6.3"
 wifiscanner = "0.5.*"
 


### PR DESCRIPTION
This is revert is required in order to support older Rust version used on buildroot.