### PR TITLE
Add Astarte Message Hub

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,6 +23,10 @@ on:
   push:
     branches: [main, 'release-*']
   pull_request:
+
+env:
+    PB_REL: https://github.com/protocolbuffers/protobuf/releases
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -46,10 +50,13 @@ jobs:
       matrix:
         toolchain: [stable]
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev libsystemd-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
@@ -64,10 +71,13 @@ jobs:
     runs-on: ubuntu-latest
     name: nightly / doc
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev libsystemd-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -79,10 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     name: ubuntu / stable / features
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev libsystemd-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
@@ -98,10 +111,13 @@ jobs:
         msrv: [1.59.0]
     name: ubuntu / ${{ matrix.msrv }}
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev libsystemd-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -26,6 +26,9 @@ on:
       - 'release-*'
   pull_request:
 
+env:
+  PB_REL: https://github.com/protocolbuffers/protobuf/releases
+
 jobs:
   codecov:
     name: cargo test
@@ -35,10 +38,13 @@ jobs:
         toolchain:
           - stable
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Install toolchain

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -26,6 +26,9 @@ on:
       - "release-*"
   pull_request:
 
+env:
+  PB_REL: https://github.com/protocolbuffers/protobuf/releases
+
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
@@ -33,10 +36,13 @@ jobs:
       REALM_NAME: edgehogdevicetest
       ASTARTE_API_URL: https://api.autotest.astarte-platform.org
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Create Astarte Cluster
         id: astarte
         uses: astarte-platform/astarte-cluster-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,10 @@ on:
   push:
     branches: [main, 'release-*']
   pull_request:
+
+env:
+  PB_REL: https://github.com/protocolbuffers/protobuf/releases
+
 name: test
 jobs:
   required:
@@ -30,10 +34,13 @@ jobs:
       matrix:
         toolchain: [stable]
     steps:
-      - name: Install libudev
+      - name: Install libudev, and Protoc
         run: |
           sudo apt update
           sudo apt-get install -y libudev-dev libsystemd-dev
+          curl -LO $PB_REL/download/v22.2/protoc-22.2-linux-x86_64.zip
+          unzip protoc-22.2-linux-x86_64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - 2023-06-05
+## [0.7.1] - Unreleased
+### Added
+- Add Astarte Message Hub library support.
 
+## [0.7.0] - 2023-06-05
 ### Added
 - Add support for `io.edgehog.devicemanager.OTAEvent` interface.
 - Add support for update/cancel operation in `io.edgehog.devicemanager.OTARequest` interface.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,33 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "ascii-canvas"
@@ -55,12 +76,12 @@ checksum = "212bcca36dfcacf39f62eed84ea400ff7dd74c18ccdfbf01c0dd039328b46afd"
 dependencies = [
  "astarte-device-sdk-derive",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bson",
  "chrono",
  "flate2",
  "http",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "log",
  "openssl",
  "reqwest",
@@ -74,7 +95,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
- "uuid 1.2.2",
+ "uuid",
  "webpki",
 ]
 
@@ -85,26 +106,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5355b4ecb5e2a4b63e8e447b2a00fed038802d26b6e29b8ddc2ee8e93acc15b"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "astarte-message-hub"
+version = "0.5.1"
+source = "git+https://github.com/astarte-platform/astarte-message-hub.git?branch=release-0.5#d8d12cf6d5d74019b7f91ce0c6713ec23ddc931a"
+dependencies = [
+ "astarte-device-sdk",
+ "async-trait",
+ "axum",
+ "chrono",
+ "clap",
+ "env_logger",
+ "log",
+ "pbjson-types",
+ "prost",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "toml",
+ "tonic",
+ "tonic-build",
+ "uuid",
+ "zbus",
+ "zvariant",
 ]
 
 [[package]]
 name = "async-broadcast"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbd92a9bd0e9c1298118ecf8a2f825e86b12c3ec9e411573e34aaf3a0c03cdd"
+checksum = "6d26004fe83b2d1cd3a97609b21e39f9a31535822210fe83205d2ce48866ea61"
 dependencies = [
- "easy-parallel",
  "event-listener",
  "futures-core",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -113,15 +160,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
 dependencies = [
+ "async-lock",
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -142,29 +189,29 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
+ "async-lock",
  "autocfg",
+ "cfg-if",
  "concurrent-queue",
  "futures-lite",
- "libc",
  "log",
- "once_cell",
  "parking",
  "polling",
+ "rustix 0.37.20",
  "slab",
  "socket2",
  "waker-fn",
- "winapi",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
 ]
@@ -180,20 +227,20 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
 dependencies = [
  "async-io",
+ "async-lock",
  "autocfg",
  "blocking",
  "cfg-if",
  "event-listener",
  "futures-lite",
- "libc",
- "once_cell",
+ "rustix 0.37.20",
  "signal-hook",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -204,7 +251,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -235,20 +282,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.2.0"
+name = "async-stream"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
-name = "async-trait"
-version = "0.1.57"
+name = "async-stream-impl"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+
+[[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -284,16 +353,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
+name = "axum"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "basic-cookies"
@@ -328,46 +444,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.2"
+name = "bitvec"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "blocking"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
 dependencies = [
  "async-channel",
+ "async-lock",
  "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell",
+ "log",
 ]
 
 [[package]]
 name = "bson"
-version = "2.3.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ecf39f5a314493ede1bb015984735d41aa6aedb59cafb95492d40cd893330"
+checksum = "9aeb8bae494e49dbc330dd23cf78f6f7accee22f640ce3ab17841badaa4ce232"
 dependencies = [
  "ahash",
- "base64 0.13.0",
+ "base64 0.13.1",
+ "bitvec",
  "chrono",
  "hex",
  "indexmap",
+ "js-sys",
  "lazy_static",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
- "time 0.3.9",
- "uuid 0.8.2",
+ "time 0.3.15",
+ "uuid",
 ]
 
 [[package]]
@@ -378,9 +509,9 @@ checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -390,15 +521,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "castaway"
@@ -408,9 +533,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -420,22 +545,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
@@ -450,33 +577,33 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
- "cache-padded",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -491,24 +618,24 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
@@ -530,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -540,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -551,23 +678,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "once_cell",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -575,12 +701,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -591,9 +716,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -611,12 +736,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -636,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.61+curl-8.0.1"
+version = "0.4.63+curl-8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
+checksum = "aeb0fef7046022a1e2ad67a004978f0e3cacb9e3123dc62ce768f92197b771dc"
 dependencies = [
  "cc",
  "libc",
@@ -658,7 +783,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -675,9 +800,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -706,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "dotenvy"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -717,16 +842,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "easy-parallel"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907e25393cdcc1f4f3f513d9aac1e840eb1cc341a0fccb01171f7d14d10b946"
-
-[[package]]
 name = "edgehog-device-runtime"
 version = "0.7.0"
 dependencies = [
  "astarte-device-sdk",
+ "astarte-message-hub",
  "async-trait",
  "bytes",
  "clap",
@@ -734,6 +854,7 @@ dependencies = [
  "httpmock",
  "log",
  "mockall",
+ "pbjson-types",
  "procfs",
  "reqwest",
  "rustc_version_runtime",
@@ -747,17 +868,19 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tonic",
  "udev",
- "uuid 0.8.2",
+ "uuid",
  "wifiscanner",
  "zbus",
+ "zvariant",
 ]
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ena"
@@ -770,18 +893,18 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "enumflags2"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -789,37 +912,26 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -845,15 +957,15 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -885,15 +997,15 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.12"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.3",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -923,13 +1035,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -946,11 +1058,10 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -967,10 +1078,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures"
-version = "0.3.21"
+name = "funty"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -983,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -993,15 +1110,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1010,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "futures-intrusive"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
 dependencies = [
  "futures-core",
  "lock_api",
@@ -1021,15 +1138,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1042,32 +1159,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1083,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1093,14 +1210,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1118,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -1137,12 +1254,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1156,14 +1267,14 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1173,6 +1284,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1191,9 +1311,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1212,10 +1332,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.7.1"
+name = "http-range-header"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1225,14 +1351,14 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "httpmock"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c159c4fc205e6c1a9b325cb7ec135d13b5f47188ce175dabb76ec847f331d9bd"
+checksum = "c6b56b6265f15908780cbee987912c1e98dbca675361f748291605a8a3a1df09"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -1259,9 +1385,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1282,6 +1408,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,24 +1433,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "iana-time-zone"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
- "matches",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1326,15 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.2"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -1343,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
@@ -1354,8 +1508,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes 1.0.10",
- "rustix 0.37.14",
+ "io-lifetimes",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -1397,24 +1551,24 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1430,19 +1584,18 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.9"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34313ec00c2eb5c3c87ca6732ea02dcf3af99c3ff7a8fb622ffb99c9d860a87"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
 dependencies = [
  "ascii-canvas",
  "bit-set",
  "diff",
  "ena",
  "is-terminal",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
- "pico-args",
  "regex",
  "regex-syntax",
  "string_cache",
@@ -1453,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.9"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c1f7869c94d214466c5fd432dfed12c379fd87786768d36455892d46b18edd"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
 dependencies = [
  "regex",
 ]
@@ -1474,9 +1627,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1522,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "libc",
@@ -1534,21 +1687,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1565,10 +1718,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
+name = "matchit"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "memchr"
@@ -1586,10 +1739,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.16"
+name = "memoffset"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1599,30 +1761,29 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -1635,15 +1796,21 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nanorand"
@@ -1656,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1680,22 +1847,22 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1709,21 +1876,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -1737,11 +1894,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1756,15 +1913,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1777,13 +1934,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1794,20 +1951,19 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.20.0+1.1.1o"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -1827,15 +1983,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -1845,7 +2001,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -1855,47 +2011,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.36.1",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pbjson"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
+dependencies = [
+ "heck",
+ "itertools 0.10.5",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a88c8d87f99a4ac14325e7a4c24af190fca261956e3b82dd7ed67e77e6c7043"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-build",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -1917,29 +2110,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "pico-args"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
-
-[[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1956,22 +2143,24 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "polling"
-version = "2.5.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
+ "bitflags",
  "cfg-if",
+ "concurrent-queue",
  "libc",
  "log",
- "wepoll-ffi",
- "windows-sys 0.42.0",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1982,9 +2171,9 @@ checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "precomputed-hash"
@@ -2000,7 +2189,7 @@ checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -2023,11 +2212,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
+name = "prettyplease"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
@@ -2041,7 +2241,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2058,18 +2258,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "procfs"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
+checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2077,17 +2277,78 @@ dependencies = [
  "flate2",
  "hex",
  "lazy_static",
- "rustix 0.35.7",
+ "rustix 0.36.14",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2110,7 +2371,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2120,7 +2381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2140,30 +2401,28 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2182,9 +2441,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
 ]
@@ -2196,15 +2464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2213,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "remove_dir_all"
@@ -2228,11 +2496,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2260,6 +2528,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2318,37 +2587,37 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.7"
+version = "0.36.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
 dependencies = [
  "bitflags",
- "errno 0.2.8",
- "io-lifetimes 0.7.2",
+ "errno",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys 0.36.1",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
- "errno 0.3.1",
- "io-lifetimes 1.0.10",
+ "errno",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.4",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2374,7 +2643,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2383,7 +2652,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -2394,18 +2663,17 @@ checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2426,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2439,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2464,38 +2732,38 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2515,13 +2783,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2553,9 +2821,9 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2574,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -2595,9 +2863,12 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "sluice"
@@ -2612,15 +2883,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -2634,9 +2905,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -2647,16 +2918,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
 dependencies = [
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "nom",
  "unicode_categories",
 ]
 
 [[package]]
 name = "sqlx"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
+checksum = "f8de3b03a925878ed54a954f621e64bf55a3c1bd29652d0d1a17830405350188"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2664,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
+checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
 dependencies = [
  "ahash",
  "atoi",
@@ -2710,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
+checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
 dependencies = [
  "dotenvy",
  "either",
@@ -2723,15 +2994,15 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn",
+ "syn 1.0.109",
  "url",
 ]
 
 [[package]]
 name = "sqlx-rt"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
+checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
 dependencies = [
  "once_cell",
  "tokio",
@@ -2775,9 +3046,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2785,10 +3056,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.26.2"
+name = "syn"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "sysinfo"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2815,6 +3103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,16 +3120,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2851,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -2872,29 +3166,29 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -2903,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
  "itoa",
  "libc",
@@ -2939,20 +3233,19 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -2960,25 +3253,35 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2997,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3022,24 +3325,114 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.1"
+name = "tonic"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -3050,20 +3443,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
@@ -3080,15 +3473,15 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "udev"
@@ -3113,30 +3506,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-xid"
@@ -3158,13 +3551,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -3176,22 +3568,12 @@ checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom",
  "serde",
- "sha1",
-]
-
-[[package]]
-name = "uuid"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
-dependencies = [
- "getrandom",
  "sha1_smol",
 ]
 
@@ -3247,9 +3629,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3257,24 +3639,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3284,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3294,28 +3676,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3341,12 +3736,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
+name = "which"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
- "cc",
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -3391,16 +3788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.36.1"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3409,13 +3802,22 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3424,7 +3826,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3444,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3456,15 +3873,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3474,15 +3885,9 @@ checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3492,15 +3897,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3510,15 +3909,9 @@ checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3528,9 +3921,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3540,15 +3933,9 @@ checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3563,6 +3950,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]
@@ -3613,7 +4009,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3650,5 +4046,5 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,11 @@ serde = "1.0.152"
 serde_json = "1.0"
 procfs = "0.14.1"
 rustc_version_runtime = "0.2"
-zbus = { version = "2", default-features = false, features = ["tokio"] }
+zbus = { version = "=2.2.0", default-features = false, features = ["tokio"] }
+zvariant = "=3.2.1"
 reqwest = { version = "0.11.12", features = ["stream"] }
 toml = "0.5.9"
-uuid = {version="0.8.2", features = ["v5", "v4"] }
+uuid = {version= "1.3.4", features = ["v5", "v4"] }
 systemd = { version = "0.10", optional = true }
 async-trait = "0.1.57"
 sysinfo = "0.26.2"
@@ -36,11 +37,14 @@ udev = "0.6.3"
 wifiscanner = "0.5.*"
 bytes = "1"
 tokio-util = "0.7.8"
+astarte-message-hub = {git ="https://github.com/astarte-platform/astarte-message-hub.git" , branch = "release-0.5"}
+tonic = "=0.8.2"
 
 [dev-dependencies]
 mockall = "0.11.3"
 tempdir = "0.3.7"
 httpmock = "0.6"
+pbjson-types = "0.5"
 
 [features]
 e2e_test = []

--- a/README.md
+++ b/README.md
@@ -48,16 +48,52 @@ Edgehog Device Runtime can be configured using a [TOML](https://en.wikipedia.org
 located either in $PWD/edgehog-config.toml or /etc/edgehog/config.toml, or in a custom path, run
 `cargo run -- --help` for more informations.
 
+
+### Supported Astarte transport libraries
+Edgehog Device Runtime supports the following libraries to communicate with the remote Edgehog
+instance:
+
+1. `astarte-device-sdk`
+2. `astarte-message-hub`
+
+#### 1. [Astarte Device SDK Rust](https://github.com/astarte-platform/astarte-device-sdk-rust) 
+The Astarte Device SDK for Rust is a ready to use library that provides communication and pairing
+primitives to an Astarte Cluster.
+
 Example configuration:
 
 ```toml
+astarte_library = "astarte-device-sdk"
+interfaces_directory = "/usr/share/edgehog/astarte-interfaces/"
+store_directory = "/var/lib/edgehog/"
+download_directory = "/var/tmp/edgehog-updates/"
+[astarte_device_sdk]
 credentials_secret = "YOUR_CREDENTIAL_SECRET"
 device_id = "YOUR_UNIQUE_DEVIDE_ID"
 pairing_url = "https://api.astarte.EXAMPLE.COM/pairing"
 realm = "examplerealm"
+[[telemetry_config]]
+interface_name = "io.edgehog.devicemanager.SystemStatus"
+enabled = true
+period = 60
+```
+
+#### [Astarte Message Hub](https://github.com/astarte-platform/astarte-message-hub)
+A central service that runs on (Linux) devices for collecting and delivering messages from N apps
+using 1 MQTT connection to Astarte.
+
+**N.B.** When using this option the Astarte Message Hub should already be installed and running
+on your system.
+
+Example configuration:
+
+```toml
+astarte_library = "astarte-message-hub"
 interfaces_directory = "/usr/share/edgehog/astarte-interfaces/"
 store_directory = "/var/lib/edgehog/"
 download_directory = "/var/tmp/edgehog-updates/"
+[astarte_message_hub]
+endpoint = "http://[::1]:50051"
 [[telemetry_config]]
 interface_name = "io.edgehog.devicemanager.SystemStatus"
 enabled = true

--- a/src/data/astarte_device_sdk_lib.rs
+++ b/src/data/astarte_device_sdk_lib.rs
@@ -18,26 +18,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use astarte_device_sdk::options::AstarteOptions;
+use astarte_device_sdk::options::{AstarteOptions, AstarteOptionsError};
 use astarte_device_sdk::types::AstarteType;
 use astarte_device_sdk::{
     registration, AstarteAggregate, AstarteDeviceDataEvent, AstarteDeviceSdk, AstarteError,
 };
 use async_trait::async_trait;
+use serde::Deserialize;
 
-use crate::data::Publisher;
+use crate::data::{Publisher, Subscriber};
 use crate::error::DeviceManagerError;
 use crate::repository::file_state_repository::FileStateRepository;
 use crate::repository::StateRepository;
 use crate::{get_hardware_id_from_dbus, DeviceManagerOptions};
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct AstarteDeviceSdkConfigOptions {
+    pub realm: String,
+    pub device_id: Option<String>,
+    pub credentials_secret: Option<String>,
+    pub pairing_url: String,
+    pub pairing_token: Option<String>,
+}
+
 #[derive(Clone)]
-pub struct Astarte {
+pub struct AstarteDeviceSdkLib {
     pub device_sdk: AstarteDeviceSdk,
 }
 
 #[async_trait]
-impl Publisher for Astarte {
+impl Publisher for AstarteDeviceSdkLib {
     async fn send_object<T: 'static>(
         &self,
         interface_name: &str,
@@ -62,36 +72,43 @@ impl Publisher for Astarte {
             .send(interface_name, interface_path, data)
             .await
     }
+}
 
+#[async_trait]
+impl Subscriber for AstarteDeviceSdkLib {
     async fn on_event(&mut self) -> Result<AstarteDeviceDataEvent, AstarteError> {
         self.device_sdk.handle_events().await
     }
 }
 
-impl Astarte {
-    pub async fn new(sdk_options: AstarteOptions) -> Result<Astarte, DeviceManagerError> {
+impl AstarteDeviceSdkLib {
+    pub async fn new(sdk_options: AstarteOptions) -> Result<Self, DeviceManagerError> {
         let device = AstarteDeviceSdk::new(&sdk_options).await?;
-        Ok(Astarte { device_sdk: device })
+        Ok(AstarteDeviceSdkLib { device_sdk: device })
     }
 }
 
 pub async fn astarte_map_options(
     opts: &DeviceManagerOptions,
 ) -> Result<AstarteOptions, DeviceManagerError> {
-    let device_id: String = get_device_id(opts.device_id.clone()).await?;
+    let astarte_device_sdk_options = opts.astarte_device_sdk.as_ref().ok_or_else(|| {
+        AstarteOptionsError::ConfigError("Unable to find Astarte SDK options".to_string())
+    })?;
+
+    let device_id: String = get_device_id(astarte_device_sdk_options.device_id.clone()).await?;
     let store_directory = opts.store_directory.to_owned();
     let credentials_secret: String = get_credentials_secret(
         &device_id,
-        opts,
+        astarte_device_sdk_options,
         FileStateRepository::new(store_directory, format!("credentials_{}.json", device_id)),
     )
     .await?;
 
     let mut sdk_options = AstarteOptions::new(
-        &opts.realm,
+        &astarte_device_sdk_options.realm,
         &device_id,
         &credentials_secret,
-        &opts.pairing_url,
+        &astarte_device_sdk_options.pairing_url,
     );
 
     if Some(true) == opts.astarte_ignore_ssl {
@@ -113,7 +130,7 @@ async fn get_device_id(opt_device_id: Option<String>) -> Result<String, DeviceMa
 
 async fn get_credentials_secret(
     device_id: &str,
-    opts: &DeviceManagerOptions,
+    opts: &AstarteDeviceSdkConfigOptions,
     cred_state_repo: impl StateRepository<String>,
 ) -> Result<String, DeviceManagerError> {
     if let Some(secret) = opts.credentials_secret.clone() {
@@ -141,7 +158,7 @@ fn get_credentials_secret_from_persistence(
 async fn get_credentials_secret_from_registration(
     device_id: &str,
     token: &str,
-    opts: &DeviceManagerOptions,
+    opts: &AstarteDeviceSdkConfigOptions,
     cred_state_repo: impl StateRepository<String>,
 ) -> Result<String, DeviceManagerError> {
     let registration =
@@ -161,12 +178,12 @@ async fn get_credentials_secret_from_registration(
 
 #[cfg(test)]
 mod tests {
-    use crate::repository::MockStateRepository;
-    use crate::{DeviceManagerError, DeviceManagerOptions};
-
-    use crate::data::astarte::{
+    use crate::data::astarte_device_sdk_lib::{
         get_credentials_secret, get_credentials_secret_from_registration, get_device_id,
+        AstarteDeviceSdkConfigOptions,
     };
+    use crate::repository::MockStateRepository;
+    use crate::{AstarteLibrary, DeviceManagerError, DeviceManagerOptions};
 
     #[tokio::test]
     async fn device_id_test() {
@@ -180,11 +197,15 @@ mod tests {
     async fn credentials_secret_test() {
         let state_mock = MockStateRepository::<String>::new();
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: None,
-            credentials_secret: Some("credentials_secret".to_string()),
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: None,
+                credentials_secret: Some("credentials_secret".to_string()),
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
@@ -192,9 +213,13 @@ mod tests {
             telemetry_config: Some(vec![]),
         };
         assert_eq!(
-            get_credentials_secret("device_id", &options, state_mock)
-                .await
-                .unwrap(),
+            get_credentials_secret(
+                "device_id",
+                &options.astarte_device_sdk.unwrap(),
+                state_mock
+            )
+            .await
+            .unwrap(),
             "credentials_secret".to_string()
         );
     }
@@ -204,20 +229,28 @@ mod tests {
         let mut state_mock = MockStateRepository::<String>::new();
         state_mock.expect_exists().returning(|| false);
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: None,
-            credentials_secret: None,
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: None,
+                credentials_secret: None,
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
-        assert!(get_credentials_secret("device_id", &options, state_mock)
-            .await
-            .is_err());
+        assert!(get_credentials_secret(
+            "device_id",
+            &options.astarte_device_sdk.unwrap(),
+            state_mock
+        )
+        .await
+        .is_err());
     }
 
     #[tokio::test]
@@ -230,11 +263,15 @@ mod tests {
             .returning(move || Err(DeviceManagerError::FatalError("".to_owned())));
 
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: Some("device_id".to_owned()),
-            credentials_secret: None,
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: Some("device_id".to_owned()),
+                credentials_secret: None,
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
@@ -242,9 +279,13 @@ mod tests {
             telemetry_config: Some(vec![]),
         };
 
-        assert!(get_credentials_secret("device_id", &options, state_mock)
-            .await
-            .is_err());
+        assert!(get_credentials_secret(
+            "device_id",
+            &options.astarte_device_sdk.unwrap(),
+            state_mock
+        )
+        .await
+        .is_err());
     }
 
     #[tokio::test]
@@ -256,11 +297,15 @@ mod tests {
             .returning(move || Ok("cred_secret".to_owned()));
 
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: Some("device_id".to_owned()),
-            credentials_secret: None,
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: Some("device_id".to_owned()),
+                credentials_secret: None,
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
@@ -268,29 +313,42 @@ mod tests {
             telemetry_config: Some(vec![]),
         };
 
-        assert!(get_credentials_secret("device_id", &options, state_mock)
-            .await
-            .is_ok());
+        assert!(get_credentials_secret(
+            "device_id",
+            &options.astarte_device_sdk.unwrap(),
+            state_mock
+        )
+        .await
+        .is_ok());
     }
 
     #[tokio::test]
     async fn get_credentials_secret_from_registration_fail() {
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: Some("device_id".to_owned()),
-            credentials_secret: Some("credentials_secret".to_string()),
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: Some("device_id".to_owned()),
+                credentials_secret: Some("credentials_secret".to_string()),
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
             interfaces_directory: "./".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
+            astarte_message_hub: None,
         };
 
         let state_mock = MockStateRepository::<String>::new();
-        let cred_result =
-            get_credentials_secret_from_registration("", "", &options, state_mock).await;
+        let cred_result = get_credentials_secret_from_registration(
+            "",
+            "",
+            &options.astarte_device_sdk.unwrap(),
+            state_mock,
+        )
+        .await;
         assert!(cred_result.is_err());
         match cred_result.err().unwrap() {
             DeviceManagerError::FatalError(val) => {

--- a/src/data/astarte_message_hub_node.rs
+++ b/src/data/astarte_message_hub_node.rs
@@ -18,35 +18,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+//! Contains the implementation for the Astarte message hub node.
+
 use astarte_message_hub::proto_message_hub;
 use async_trait::async_trait;
 use log::warn;
 use serde::Deserialize;
+use std::time::Duration;
+use tonic::Response as TonicResponse;
+use tonic::Streaming as TonicStreaming;
 
 use crate::data::{Publisher, Subscriber};
 use crate::error::DeviceManagerError;
 
+/// Device runtime node identifier.
+const DEVICE_RUNTIME_NODE_UUID: &str = "d72a6187-7cf1-44cc-87e8-e991936166db";
+
+/// Struct containing the configuration options for the Astarte message hub.
 #[derive(Debug, Deserialize, Clone)]
-pub struct AstarteMessageHubConfigOptions {
-    pub endpoint: String,
+pub struct AstarteMessageHubOptions {
+    /// The Endpoint of the Astarte Message Hub
+    endpoint: String,
 }
 
-type AstarteDataSender = tokio::sync::oneshot::Sender<
+/// Shorthand for the transmit Astarte data event in [`run_node`] function.
+type AstarteDataEventSender = tokio::sync::oneshot::Sender<
     Result<astarte_device_sdk::AstarteDeviceDataEvent, astarte_device_sdk::AstarteError>,
 >;
 
-const DEVICE_RUNTIME_NODE_UUID: &str = "d72a6187-7cf1-44cc-87e8-e991936166db";
-
-/// Provides the communication with Astarte Message Hub Node.
+/// Main struct for the Astarte message hub node.
+/// Contains the communication with Astarte Message Hub.
 #[derive(Clone)]
 pub struct AstarteMessageHubNode {
     transport_channel: tonic::transport::Channel,
-    sender: tokio::sync::mpsc::Sender<AstarteDataSender>,
+    sender: tokio::sync::mpsc::Sender<AstarteDataEventSender>,
 }
 
 impl AstarteMessageHubNode {
     pub async fn new(
-        options: AstarteMessageHubConfigOptions,
+        options: AstarteMessageHubOptions,
         interfaces_directory: String,
     ) -> Result<Self, DeviceManagerError> {
         let (sender, receiver) = tokio::sync::mpsc::channel(8);
@@ -54,6 +64,7 @@ impl AstarteMessageHubNode {
         use proto_message_hub::message_hub_client::MessageHubClient;
         let channel = tonic::transport::Channel::from_shared(options.endpoint)
             .map_err(|err| DeviceManagerError::FatalError(err.to_string()))?
+            .http2_keep_alive_interval(Duration::from_secs(5))
             .connect()
             .await?;
 
@@ -70,7 +81,13 @@ impl AstarteMessageHubNode {
             .await?
             .into_inner();
 
-        tokio::spawn(run_node(stream_channel, receiver));
+        let channel_clone = channel.clone();
+        tokio::spawn(run_node(
+            interfaces_directory,
+            channel_clone,
+            stream_channel,
+            receiver,
+        ));
 
         Ok(Self {
             transport_channel: channel,
@@ -78,6 +95,7 @@ impl AstarteMessageHubNode {
         })
     }
 
+    ///Send an Astarte message payload to the Astarte Message Hub.
     async fn send_payload(
         &self,
         interface_name: &str,
@@ -150,7 +168,7 @@ impl Subscriber for AstarteMessageHubNode {
         let (astarte_data_event_tx, astarte_data_event_rx) = tokio::sync::oneshot::channel();
 
         self.sender.send(astarte_data_event_tx).await.map_err(|_| {
-            astarte_device_sdk::AstarteError::SendError("Unable to receive message".to_string())
+            astarte_device_sdk::AstarteError::SendError("Sender dropped".to_string())
         })?;
 
         astarte_data_event_rx.await.map_err(|_| {
@@ -160,13 +178,19 @@ impl Subscriber for AstarteMessageHubNode {
 }
 
 /// Runner function for the AstarteMessageHubNode.
+///
+/// This function receives message from Astarte Message hub and forward it to the device runtime.
+/// If this function receives an Error with Status [`tonic::Code::Unavailable`] or [`tonic::Code::Unknown`]
+/// it will retry to attach the node to Astarte Message Hub.
 pub async fn run_node(
+    path: String,
+    transport_channel: tonic::transport::Channel,
     mut stream_node_event: tonic::Streaming<proto_message_hub::AstarteMessage>,
-    mut receiver: tokio::sync::mpsc::Receiver<AstarteDataSender>,
+    mut receiver: tokio::sync::mpsc::Receiver<AstarteDataEventSender>,
 ) {
     while let Some(respond_to) = receiver.recv().await {
-        let astarte_data_result = if let Ok(option_message) = stream_node_event.message().await {
-            option_message
+        let astarte_data_result = match stream_node_event.message().await {
+            Ok(option_message) => option_message
                 .ok_or_else(|| {
                     astarte_device_sdk::AstarteError::ReceiveError(
                         "Empty message received".to_string(),
@@ -175,17 +199,60 @@ pub async fn run_node(
                 .and_then(|astarte_message| {
                     astarte_device_sdk::AstarteDeviceDataEvent::try_from(astarte_message)
                         .map_err(|_| astarte_device_sdk::AstarteError::Conversion)
-                })
-        } else {
-            Err(astarte_device_sdk::AstarteError::ReceiveError(
+                }),
+            Err(status)
+                if (status.code() == tonic::Code::Unavailable
+                    || status.code() == tonic::Code::Unknown) =>
+            {
+                // Server shutting down or Server side application throws an exception
+                stream_node_event = retry_to_attach_node(&path, transport_channel.clone())
+                    .await
+                    .into_inner();
+
+                Err(astarte_device_sdk::AstarteError::ReceiveError(
+                    "Error during receive message from Astarte Message Hub, Server Unavailable"
+                        .to_string(),
+                ))
+            }
+            _ => Err(astarte_device_sdk::AstarteError::ReceiveError(
                 "Error during receive message from Astarte Message Hub".to_string(),
-            ))
+            )),
         };
 
         if respond_to.send(astarte_data_result).is_err() {
             warn!("respond_sender dropped before reply")
         }
     }
+}
+
+/// Retries to attach the node to the Astarte Message Hub.
+async fn retry_to_attach_node(
+    interface_path: &str,
+    transport_channel: tonic::transport::Channel,
+) -> TonicResponse<TonicStreaming<proto_message_hub::AstarteMessage>> {
+    use proto_message_hub::message_hub_client::MessageHubClient;
+
+    let interface_json = read_interfaces_from_directory(interface_path).unwrap();
+
+    let node = proto_message_hub::Node {
+        uuid: DEVICE_RUNTIME_NODE_UUID.to_string(),
+        interface_jsons: interface_json,
+    };
+
+    let mut attach_node_result = MessageHubClient::new(transport_channel.clone())
+        .attach(tonic::Request::new(node.clone()))
+        .await;
+
+    let mut interval = tokio::time::interval(Duration::from_secs(5));
+
+    while attach_node_result.is_err() {
+        interval.tick().await;
+        attach_node_result = MessageHubClient::new(transport_channel.clone())
+            .attach(tonic::Request::new(node.clone()))
+            .await
+    }
+
+    attach_node_result.unwrap()
 }
 
 fn read_interfaces_from_directory(
@@ -223,7 +290,7 @@ mod tests {
     use tonic::{Code, Request, Response, Status};
 
     use crate::data::astarte_message_hub_node::{
-        read_interfaces_from_directory, AstarteMessageHubConfigOptions, AstarteMessageHubNode,
+        read_interfaces_from_directory, AstarteMessageHubNode, AstarteMessageHubOptions,
     };
     use crate::data::{Publisher, Subscriber};
 
@@ -326,7 +393,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50052).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50053".to_string(),
             },
             "/tmp".to_string(),
@@ -349,7 +416,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),
@@ -375,7 +442,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),
@@ -405,7 +472,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),
@@ -446,7 +513,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),
@@ -487,7 +554,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),
@@ -535,7 +602,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),
@@ -591,7 +658,7 @@ mod tests {
         let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
 
         let node_result = AstarteMessageHubNode::new(
-            AstarteMessageHubConfigOptions {
+            AstarteMessageHubOptions {
                 endpoint: "http://[::1]:50051".to_string(),
             },
             "/tmp".to_string(),

--- a/src/data/astarte_message_hub_node.rs
+++ b/src/data/astarte_message_hub_node.rs
@@ -1,0 +1,611 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use astarte_message_hub::proto_message_hub;
+use async_trait::async_trait;
+use log::warn;
+use serde::Deserialize;
+
+use crate::data::{Publisher, Subscriber};
+use crate::error::DeviceManagerError;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct AstarteMessageHubConfigOptions {
+    pub endpoint: String,
+}
+
+type AstarteDataSender = tokio::sync::oneshot::Sender<
+    Result<astarte_device_sdk::AstarteDeviceDataEvent, astarte_device_sdk::AstarteError>,
+>;
+
+const DEVICE_RUNTIME_NODE_UUID: &str = "d72a6187-7cf1-44cc-87e8-e991936166db";
+
+/// Provides the communication with Astarte Message Hub Node.
+#[derive(Clone)]
+pub struct AstarteMessageHubNode {
+    transport_channel: tonic::transport::Channel,
+    sender: tokio::sync::mpsc::Sender<AstarteDataSender>,
+}
+
+impl AstarteMessageHubNode {
+    pub async fn new(
+        options: AstarteMessageHubConfigOptions,
+        interfaces_directory: String,
+    ) -> Result<Self, DeviceManagerError> {
+        let (sender, receiver) = tokio::sync::mpsc::channel(8);
+
+        use proto_message_hub::message_hub_client::MessageHubClient;
+        let channel = tonic::transport::Channel::from_shared(options.endpoint)
+            .map_err(|err| DeviceManagerError::FatalError(err.to_string()))?
+            .connect()
+            .await?;
+
+        let mut message_hub_client = MessageHubClient::new(channel.clone());
+        let interface_json = read_interfaces_from_directory(&interfaces_directory)?;
+
+        let node = proto_message_hub::Node {
+            uuid: DEVICE_RUNTIME_NODE_UUID.to_string(),
+            interface_jsons: interface_json,
+        };
+
+        let stream_channel = message_hub_client
+            .attach(tonic::Request::new(node))
+            .await?
+            .into_inner();
+
+        tokio::spawn(run_node(stream_channel, receiver));
+
+        Ok(Self {
+            transport_channel: channel,
+            sender,
+        })
+    }
+
+    async fn send_payload(
+        &self,
+        interface_name: &str,
+        interface_path: &str,
+        payload: proto_message_hub::astarte_message::Payload,
+    ) -> Result<(), astarte_device_sdk::AstarteError> {
+        use proto_message_hub::message_hub_client::MessageHubClient;
+
+        let astarte_message = proto_message_hub::AstarteMessage {
+            interface_name: interface_name.to_string(),
+            path: interface_path.to_string(),
+            timestamp: None,
+            payload: Some(payload),
+        };
+
+        let mut message_hub_client = MessageHubClient::new(self.transport_channel.clone());
+        message_hub_client
+            .send(tonic::Request::new(astarte_message))
+            .await
+            .map_err(|err| {
+                astarte_device_sdk::AstarteError::SendError(err.message().to_string())
+            })?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Publisher for AstarteMessageHubNode {
+    async fn send_object<T: 'static>(
+        &self,
+        interface_name: &str,
+        interface_path: &str,
+        data: T,
+    ) -> Result<(), astarte_device_sdk::AstarteError>
+    where
+        T: astarte_device_sdk::AstarteAggregate + Send,
+    {
+        let payload: proto_message_hub::astarte_message::Payload = data
+            .astarte_aggregate()?
+            .try_into()
+            .map_err(|_| astarte_device_sdk::AstarteError::Conversion)?;
+
+        self.send_payload(interface_name, interface_path, payload)
+            .await
+    }
+
+    async fn send(
+        &self,
+        interface_name: &str,
+        interface_path: &str,
+        data: astarte_device_sdk::types::AstarteType,
+    ) -> Result<(), astarte_device_sdk::AstarteError> {
+        use astarte_message_hub::proto_message_hub::astarte_message::Payload;
+
+        let payload: Payload = data
+            .try_into()
+            .map_err(|_| astarte_device_sdk::AstarteError::Conversion)?;
+
+        self.send_payload(interface_name, interface_path, payload)
+            .await
+    }
+}
+
+#[async_trait]
+impl Subscriber for AstarteMessageHubNode {
+    async fn on_event(
+        &mut self,
+    ) -> Result<astarte_device_sdk::AstarteDeviceDataEvent, astarte_device_sdk::AstarteError> {
+        let (astarte_data_event_tx, astarte_data_event_rx) = tokio::sync::oneshot::channel();
+
+        self.sender.send(astarte_data_event_tx).await.map_err(|_| {
+            astarte_device_sdk::AstarteError::SendError("Unable to receive message".to_string())
+        })?;
+
+        astarte_data_event_rx.await.map_err(|_| {
+            astarte_device_sdk::AstarteError::SendError("Unable to receive message".to_string())
+        })?
+    }
+}
+
+/// Runner function for the AstarteMessageHubNode.
+pub async fn run_node(
+    mut stream_node_event: tonic::Streaming<proto_message_hub::AstarteMessage>,
+    mut receiver: tokio::sync::mpsc::Receiver<AstarteDataSender>,
+) {
+    while let Some(respond_to) = receiver.recv().await {
+        let astarte_data_result = if let Ok(option_message) = stream_node_event.message().await {
+            option_message
+                .ok_or_else(|| {
+                    astarte_device_sdk::AstarteError::ReceiveError(
+                        "Empty message received".to_string(),
+                    )
+                })
+                .and_then(|astarte_message| {
+                    astarte_device_sdk::AstarteDeviceDataEvent::try_from(astarte_message)
+                        .map_err(|_| astarte_device_sdk::AstarteError::Conversion)
+                })
+        } else {
+            Err(astarte_device_sdk::AstarteError::ReceiveError(
+                "Error during receive message from Astarte Message Hub".to_string(),
+            ))
+        };
+
+        if respond_to.send(astarte_data_result).is_err() {
+            warn!("respond_sender dropped before reply")
+        }
+    }
+}
+
+fn read_interfaces_from_directory(
+    interfaces_directory: &str,
+) -> Result<Vec<Vec<u8>>, DeviceManagerError> {
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    let interface_files = std::fs::read_dir(Path::new(interfaces_directory))?;
+    let json_extension = OsStr::new("json");
+    Ok(interface_files
+        .filter_map(Result::ok)
+        .filter(|f| {
+            f.path()
+                .extension()
+                .map_or_else(|| false, |ext| ext == json_extension)
+        })
+        .map(|it| std::fs::read(it.path()))
+        .filter_map(Result::ok)
+        .collect::<Vec<Vec<u8>>>())
+}
+
+#[cfg(test)]
+mod tests {
+    use astarte_device_sdk::types::AstarteType;
+    use astarte_device_sdk::AstarteAggregate;
+    use astarte_message_hub::proto_message_hub::astarte_message::Payload;
+    use astarte_message_hub::proto_message_hub::AstarteMessage;
+    use std::io::Write;
+    use std::net::{Ipv6Addr, SocketAddr};
+    use std::time::Duration;
+    use tempdir::TempDir;
+    use tokio::sync::oneshot::Sender;
+    use tokio::task::JoinHandle;
+    use tonic::{Code, Request, Response, Status};
+
+    use crate::data::astarte_message_hub_node::{
+        read_interfaces_from_directory, AstarteMessageHubConfigOptions, AstarteMessageHubNode,
+    };
+    use crate::data::{Publisher, Subscriber};
+
+    mockall::mock! {
+        MsgHub {}
+        #[tonic::async_trait]
+        impl astarte_message_hub::proto_message_hub::message_hub_server::MessageHub for MsgHub{
+            type AttachStream = tokio_stream::wrappers::ReceiverStream<Result<astarte_message_hub::proto_message_hub::AstarteMessage, Status>>;
+            pub async fn attach(
+                &self,
+                request: Request<astarte_message_hub::proto_message_hub::Node>,
+            ) -> Result<Response<<Self as astarte_message_hub::proto_message_hub::message_hub_server::MessageHub>::AttachStream>, Status> ;
+            pub async fn send(
+                &self,
+                request: Request<astarte_message_hub::proto_message_hub::AstarteMessage>,
+            ) -> Result<Response<pbjson_types::Empty>, Status> ;
+            pub async fn detach(
+                &self,
+                request: Request<astarte_message_hub::proto_message_hub::Node>,
+            ) -> Result<Response<pbjson_types::Empty>, Status> ;
+        }
+    }
+
+    async fn run_local_server(msg_hub: MockMsgHub, port: u16) -> (JoinHandle<()>, Sender<()>) {
+        use crate::data::astarte_message_hub_node::proto_message_hub::message_hub_server::MessageHubServer;
+
+        let (drop_tx, drop_rx) = tokio::sync::oneshot::channel::<()>();
+        let addr: SocketAddr = (Ipv6Addr::LOCALHOST, port).into();
+        let mut listener = tokio::net::TcpListener::bind(addr).await;
+
+        while listener.is_err() {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            listener = tokio::net::TcpListener::bind(addr).await
+        }
+
+        let handle = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(MessageHubServer::new(msg_hub))
+                .serve_with_incoming_shutdown(
+                    tokio_stream::wrappers::TcpListenerStream::new(listener.expect("bind")),
+                    async { drop_rx.await.unwrap() },
+                )
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        (handle, drop_tx)
+    }
+
+    #[test]
+    fn read_interfaces_from_directory_empty() {
+        let dir = TempDir::new("edgehog").unwrap();
+        let t_dir = dir.path().to_str().unwrap();
+        let read_result = read_interfaces_from_directory(t_dir);
+
+        assert!(read_result.is_ok());
+        assert!(read_result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn read_interfaces_from_directory_1_interface() {
+        use std::fs::File;
+        let dir = TempDir::new("edgehog").unwrap();
+        let t_dir = dir.path().to_str().unwrap();
+
+        const SERV_PROPS_IFACE: &str = r#"
+        {
+            "interface_name": "org.astarte-platform.test.test",
+            "version_major": 1,
+            "version_minor": 1,
+            "type": "properties",
+            "ownership": "server",
+            "mappings": [
+                {
+                    "endpoint": "/button",
+                    "type": "boolean",
+                    "explicit_timestamp": true
+                },
+            ]
+        }
+        "#;
+
+        let file_name = "org.astarte-platform.test.test.json";
+        let mut file = File::create(format!("{}/{}", t_dir, file_name)).unwrap();
+        file.write_all(SERV_PROPS_IFACE.as_bytes())
+            .expect("Unable to write interface file");
+
+        let read_result = read_interfaces_from_directory(t_dir);
+
+        assert!(read_result.is_ok());
+        let interfaces = read_result.unwrap();
+        assert_eq!(interfaces.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn attach_connect_fail() {
+        let msg_hub = MockMsgHub::new();
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50052).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50053".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+        assert!(node_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn attach_node_fail() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub
+            .expect_attach()
+            .returning(|_| Err(tonic::Status::new(Code::Internal, "".to_string())));
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+        assert!(node_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn attach_success() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub.expect_attach().returning(|_| {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
+        });
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+        assert!(node_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_fail() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub.expect_attach().returning(|_| {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
+        });
+
+        msg_hub
+            .expect_send()
+            .returning(|_| Err(tonic::Status::new(Code::Internal, "".to_string())));
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        assert!(node_result.is_ok());
+        let node = node_result.unwrap();
+
+        let send_result = node
+            .send(
+                "test.Individual",
+                "/sValue",
+                AstarteType::String("value".to_string()),
+            )
+            .await;
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+
+        assert!(send_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_success() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub.expect_attach().returning(|_| {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
+        });
+
+        msg_hub
+            .expect_send()
+            .returning(|_| Ok(Response::new(pbjson_types::Empty {})));
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        assert!(node_result.is_ok());
+        let node = node_result.unwrap();
+
+        let send_result = node
+            .send(
+                "test.Individual",
+                "/sValue",
+                AstarteType::String("value".to_string()),
+            )
+            .await;
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+
+        assert!(send_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_object_fail() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub.expect_attach().returning(|_| {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
+        });
+
+        msg_hub
+            .expect_send()
+            .returning(|_| Err(tonic::Status::new(Code::Internal, "".to_string())));
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        assert!(node_result.is_ok());
+        let node = node_result.unwrap();
+
+        #[derive(AstarteAggregate)]
+        struct Obj {
+            s_value: String,
+        }
+
+        let send_result = node
+            .send_object(
+                "test.Object",
+                "/obj",
+                Obj {
+                    s_value: "test".to_string(),
+                },
+            )
+            .await;
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+
+        assert!(send_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_object_success() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub.expect_attach().returning(|_| {
+            let (_, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
+        });
+
+        msg_hub
+            .expect_send()
+            .returning(|_| Ok(Response::new(pbjson_types::Empty {})));
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        assert!(node_result.is_ok());
+        let node = node_result.unwrap();
+
+        #[derive(AstarteAggregate)]
+        struct Obj {
+            s_value: String,
+        }
+
+        let send_result = node
+            .send_object(
+                "test.Object",
+                "/obj",
+                Obj {
+                    s_value: "test".to_string(),
+                },
+            )
+            .await;
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+
+        assert!(send_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn receive_success() {
+        let mut msg_hub = MockMsgHub::new();
+
+        msg_hub.expect_attach().returning(|_| {
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                tx.send(Ok(AstarteMessage {
+                    interface_name: "test.server.Value".to_string(),
+                    path: "/req".to_string(),
+                    timestamp: None,
+                    payload: Some(Payload::AstarteData(5.into())),
+                }))
+                .await
+                .expect("send astarte message");
+            });
+
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
+        });
+
+        let (server_handle, drop_sender) = run_local_server(msg_hub, 50051).await;
+
+        let node_result = AstarteMessageHubNode::new(
+            AstarteMessageHubConfigOptions {
+                endpoint: "http://[::1]:50051".to_string(),
+            },
+            "/tmp".to_string(),
+        )
+        .await;
+
+        assert!(node_result.is_ok());
+        let mut node = node_result.unwrap();
+
+        let data_receive_result = node.on_event().await;
+
+        drop_sender.send(()).expect("send shutdown");
+        server_handle.await.expect("server shutdown");
+
+        assert!(data_receive_result.is_ok());
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -24,7 +24,8 @@ use async_trait::async_trait;
 #[cfg(test)]
 use mockall::automock;
 
-pub mod astarte;
+pub mod astarte_device_sdk_lib;
+pub mod astarte_message_hub_node;
 
 #[cfg_attr(test, automock)]
 #[async_trait]
@@ -44,6 +45,10 @@ pub trait Publisher: Send + Sync {
         interface_path: &str,
         data: AstarteType,
     ) -> Result<(), AstarteError>;
+}
 
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait Subscriber {
     async fn on_event(&mut self) -> Result<AstarteDeviceDataEvent, AstarteError>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum DeviceManagerError {
     #[error(transparent)]
     AstarteBuilderError(#[from] astarte_device_sdk::options::AstarteOptionsError),
 
+    #[error("Astarte Message Hub Options error ({0})")]
+    AstarteMessageHubOptions(String),
+
     #[error(transparent)]
     AstarteError(#[from] astarte_device_sdk::AstarteError),
 
@@ -54,4 +57,10 @@ pub enum DeviceManagerError {
 
     #[error("integer parse error")]
     ParseIntError(#[from] std::num::ParseIntError),
+
+    #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::RwLock;
 
-use crate::data::Publisher;
+use crate::data::{Publisher, Subscriber};
 use crate::device::DeviceProxy;
 use crate::error::DeviceManagerError;
 use crate::ota::ota_handler::OtaHandler;
@@ -46,13 +46,19 @@ pub mod wrapper;
 
 const MAX_OTA_OPERATION: usize = 2;
 
+#[derive(Deserialize, Debug, Clone)]
+pub enum AstarteLibrary {
+    #[serde(rename = "astarte-device-sdk")]
+    AstarteDeviceSDK,
+    #[serde(rename = "astarte-message-hub")]
+    AstarteMessageHub,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct DeviceManagerOptions {
-    pub realm: String,
-    pub device_id: Option<String>,
-    pub credentials_secret: Option<String>,
-    pub pairing_url: String,
-    pub pairing_token: Option<String>,
+    pub astarte_library: AstarteLibrary,
+    pub astarte_device_sdk: Option<data::astarte_device_sdk_lib::AstarteDeviceSdkConfigOptions>,
+    pub astarte_message_hub: Option<data::astarte_message_hub_node::AstarteMessageHubConfigOptions>,
     pub interfaces_directory: String,
     pub store_directory: String,
     pub download_directory: String,
@@ -60,7 +66,7 @@ pub struct DeviceManagerOptions {
     pub telemetry_config: Option<Vec<telemetry::TelemetryInterfaceConfig>>,
 }
 
-pub struct DeviceManager<T: Publisher + Clone> {
+pub struct DeviceManager<T: Publisher + Subscriber + Clone> {
     publisher: T,
     //we pass all Astarte event through a channel, to avoid blocking the main loop
     ota_event_channel: Sender<AstarteDeviceDataEvent>,
@@ -68,7 +74,7 @@ pub struct DeviceManager<T: Publisher + Clone> {
     telemetry: Arc<RwLock<telemetry::Telemetry>>,
 }
 
-impl<T: Publisher + Clone + 'static> DeviceManager<T> {
+impl<T: Publisher + Subscriber + Clone + 'static> DeviceManager<T> {
     pub async fn new(
         opts: DeviceManagerOptions,
         publisher: T,
@@ -336,8 +342,15 @@ pub async fn get_hardware_id_from_dbus() -> Result<String, DeviceManagerError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::data::astarte::{astarte_map_options, Astarte};
-    use crate::data::MockPublisher;
+    use astarte_device_sdk::types::AstarteType;
+    use astarte_device_sdk::{AstarteAggregate, AstarteDeviceDataEvent};
+    use async_trait::async_trait;
+    use mockall::mock;
+
+    use crate::data::astarte_device_sdk_lib::{
+        astarte_map_options, AstarteDeviceSdkConfigOptions, AstarteDeviceSdkLib,
+    };
+    use crate::data::{Publisher, Subscriber};
     use crate::telemetry::base_image::get_base_image;
     use crate::telemetry::battery_status::{get_battery_status, BatteryStatus};
     use crate::telemetry::hardware_info::get_hardware_info;
@@ -347,26 +360,55 @@ mod tests {
     use crate::telemetry::storage_usage::{get_storage_usage, DiskUsage};
     use crate::telemetry::system_info::get_system_info;
     use crate::telemetry::system_status::{get_system_status, SystemStatus};
-    use crate::{DeviceManager, DeviceManagerOptions, TelemetryMessage, TelemetryPayload};
-    use astarte_device_sdk::types::AstarteType;
+    use crate::{
+        AstarteLibrary, DeviceManager, DeviceManagerOptions, TelemetryMessage, TelemetryPayload,
+    };
 
-    impl Clone for MockPublisher {
-        fn clone(&self) -> Self {
-            MockPublisher::new()
+    mock! {
+        AstarteHandler { }
+
+        impl Clone for AstarteHandler {
+            fn clone(&self) -> Self;
         }
 
-        fn clone_from(&mut self, _: &Self) {}
+         #[async_trait]
+        impl Publisher for AstarteHandler {
+            async fn send_object<T: 'static>(
+                &self,
+                interface_name: &str,
+                interface_path: &str,
+                data: T,
+            ) -> Result<(), astarte_device_sdk::AstarteError>
+            where
+                T: AstarteAggregate + Send;
+
+            async fn send(
+                &self,
+                interface_name: &str,
+                interface_path: &str,
+                data: AstarteType,
+            ) -> Result<(), astarte_device_sdk::AstarteError>;
+        }
+
+        #[async_trait]
+        impl Subscriber for AstarteHandler {
+            async fn on_event(&mut self) -> Result<AstarteDeviceDataEvent, astarte_device_sdk::AstarteError>;
+        }
     }
 
     #[tokio::test]
     #[should_panic]
     async fn device_new_sdk_panic_fail() {
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: Some("device_id".to_string()),
-            credentials_secret: Some("credentials_secret".to_string()),
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: Some("device_id".to_string()),
+                credentials_secret: Some("credentials_secret".to_string()),
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "./".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
@@ -375,8 +417,8 @@ mod tests {
         };
 
         let astarte_options = astarte_map_options(&options).await.unwrap();
-        let astarte = Astarte::new(astarte_options).await.unwrap();
-        let dm = DeviceManager::new(options, astarte).await;
+        let astarte_device_sdk_lib = AstarteDeviceSdkLib::new(astarte_options).await.unwrap();
+        let dm = DeviceManager::new(options, astarte_device_sdk_lib).await;
 
         assert!(dm.is_ok());
     }
@@ -384,11 +426,15 @@ mod tests {
     #[tokio::test]
     async fn device_manager_new_success() {
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: Some("device_id".to_string()),
-            credentials_secret: Some("credentials_secret".to_string()),
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: Some("device_id".to_string()),
+                credentials_secret: Some("credentials_secret".to_string()),
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
@@ -396,7 +442,12 @@ mod tests {
             telemetry_config: Some(vec![]),
         };
 
-        let dm = DeviceManager::new(options, MockPublisher::new()).await;
+        let mut mock_astarte_handler = MockAstarteHandler::new();
+        mock_astarte_handler
+            .expect_clone()
+            .returning(MockAstarteHandler::new);
+
+        let dm = DeviceManager::new(options, mock_astarte_handler).await;
         if let Err(ref e) = dm {
             println!("{:?}", e);
         }
@@ -406,11 +457,15 @@ mod tests {
     #[tokio::test]
     async fn send_initial_telemetry_success() {
         let options = DeviceManagerOptions {
-            realm: "".to_string(),
-            device_id: Some("device_id".to_string()),
-            credentials_secret: Some("credentials_secret".to_string()),
-            pairing_url: "".to_string(),
-            pairing_token: None,
+            astarte_library: AstarteLibrary::AstarteDeviceSDK,
+            astarte_device_sdk: Some(AstarteDeviceSdkConfigOptions {
+                realm: "".to_string(),
+                device_id: Some("device_id".to_string()),
+                credentials_secret: Some("credentials_secret".to_string()),
+                pairing_url: "".to_string(),
+                pairing_token: None,
+            }),
+            astarte_message_hub: None,
             interfaces_directory: "./".to_string(),
             store_directory: "".to_string(),
             download_directory: "".to_string(),
@@ -419,8 +474,12 @@ mod tests {
         };
 
         let os_info = get_os_info().unwrap();
-        let mut publisher = MockPublisher::new();
-        publisher
+        let mut mock_astarte_handler = MockAstarteHandler::new();
+
+        mock_astarte_handler
+            .expect_clone()
+            .returning(MockAstarteHandler::new);
+        mock_astarte_handler
             .expect_send()
             .withf(
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
@@ -431,7 +490,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
 
         let hardware_info = get_hardware_info().unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send()
             .withf(
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
@@ -442,7 +501,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
 
         let runtime_info = get_runtime_info().unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send()
             .withf(
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
@@ -453,7 +512,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
 
         let storage_usage = get_storage_usage().unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send_object()
             .withf(
                 move |interface_name: &str, interface_path: &str, _: &DiskUsage| {
@@ -464,7 +523,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: DiskUsage| Ok(()));
 
         let network_iface_props = get_network_interface_properties().await.unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send()
             .withf(
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
@@ -475,7 +534,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
 
         let system_info = get_system_info().unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send()
             .withf(
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
@@ -486,7 +545,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
 
         let base_image = get_base_image().unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send()
             .withf(
                 move |interface_name: &str, interface_path: &str, data: &AstarteType| {
@@ -496,7 +555,7 @@ mod tests {
             )
             .returning(|_: &str, _: &str, _: AstarteType| Ok(()));
 
-        let dm = DeviceManager::new(options, publisher).await;
+        let dm = DeviceManager::new(options, mock_astarte_handler).await;
         assert!(dm.is_ok());
 
         let telemetry_result = dm.unwrap().send_initial_telemetry().await;
@@ -506,8 +565,8 @@ mod tests {
     #[tokio::test]
     async fn send_telemetry_success() {
         let system_status = get_system_status().unwrap();
-        let mut publisher: MockPublisher = MockPublisher::new();
-        publisher
+        let mut mock_astarte_handler: MockAstarteHandler = MockAstarteHandler::new();
+        mock_astarte_handler
             .expect_send_object()
             .withf(
                 move |interface_name: &str, interface_path: &str, _: &SystemStatus| {
@@ -518,7 +577,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: SystemStatus| Ok(()));
 
         let storage_usage = get_storage_usage().unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send_object()
             .withf(
                 move |interface_name: &str, interface_path: &str, _: &DiskUsage| {
@@ -529,7 +588,7 @@ mod tests {
             .returning(|_: &str, _: &str, _: DiskUsage| Ok(()));
 
         let battery_status = get_battery_status().await.unwrap();
-        publisher
+        mock_astarte_handler
             .expect_send_object()
             .withf(
                 move |interface_name: &str, interface_path: &str, _: &BatteryStatus| {
@@ -539,8 +598,8 @@ mod tests {
             )
             .returning(|_: &str, _: &str, _: BatteryStatus| Ok(()));
 
-        DeviceManager::<MockPublisher>::send_telemetry(
-            &publisher,
+        DeviceManager::<MockAstarteHandler>::send_telemetry(
+            &mock_astarte_handler,
             TelemetryMessage {
                 path: "".to_string(),
                 payload: TelemetryPayload::SystemStatus(system_status),
@@ -548,8 +607,8 @@ mod tests {
         )
         .await;
         for (path, payload) in get_storage_usage().unwrap() {
-            DeviceManager::<MockPublisher>::send_telemetry(
-                &publisher,
+            DeviceManager::<MockAstarteHandler>::send_telemetry(
+                &mock_astarte_handler,
                 TelemetryMessage {
                     path,
                     payload: TelemetryPayload::StorageUsage(payload),
@@ -558,8 +617,8 @@ mod tests {
             .await;
         }
         for (path, payload) in get_battery_status().await.unwrap() {
-            DeviceManager::<MockPublisher>::send_telemetry(
-                &publisher,
+            DeviceManager::<MockAstarteHandler>::send_telemetry(
+                &mock_astarte_handler,
                 TelemetryMessage {
                     path,
                     payload: TelemetryPayload::BatteryStatus(payload),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub enum AstarteLibrary {
 pub struct DeviceManagerOptions {
     pub astarte_library: AstarteLibrary,
     pub astarte_device_sdk: Option<data::astarte_device_sdk_lib::AstarteDeviceSdkConfigOptions>,
-    pub astarte_message_hub: Option<data::astarte_message_hub_node::AstarteMessageHubConfigOptions>,
+    pub astarte_message_hub: Option<data::astarte_message_hub_node::AstarteMessageHubOptions>,
     pub interfaces_directory: String,
     pub store_directory: String,
     pub download_directory: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ async fn main() -> Result<(), DeviceManagerError> {
                 .astarte_message_hub
                 .clone()
                 .expect("Unable to find MessageHub options");
+
             let mut dm = edgehog_device_runtime::DeviceManager::new(
                 options,
                 AstarteMessageHubNode::new(astarte_message_hub_options, interfaces_directory)

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use std::panic::{self, PanicInfo};
 use std::path::Path;
 
 use config::read_options;
-use edgehog_device_runtime::data::astarte::{astarte_map_options, Astarte};
 use edgehog_device_runtime::error::DeviceManagerError;
+use edgehog_device_runtime::AstarteLibrary;
 
 mod config;
 
@@ -74,13 +74,43 @@ async fn main() -> Result<(), DeviceManagerError> {
         })?;
     }
 
-    let astarte_options = astarte_map_options(&options).await?;
-    let astarte = Astarte::new(astarte_options).await?;
-    let mut dm = edgehog_device_runtime::DeviceManager::new(options, astarte).await?;
+    match &options.astarte_library {
+        AstarteLibrary::AstarteDeviceSDK => {
+            use edgehog_device_runtime::data::astarte_device_sdk_lib::{
+                astarte_map_options, AstarteDeviceSdkLib,
+            };
 
-    dm.init().await?;
+            let astarte_options = astarte_map_options(&options).await?;
+            let mut dm = edgehog_device_runtime::DeviceManager::new(
+                options,
+                AstarteDeviceSdkLib::new(astarte_options).await?,
+            )
+            .await?;
 
-    dm.run().await;
+            dm.init().await?;
+
+            dm.run().await;
+        }
+        AstarteLibrary::AstarteMessageHub => {
+            use edgehog_device_runtime::data::astarte_message_hub_node::AstarteMessageHubNode;
+
+            let interfaces_directory = options.interfaces_directory.clone();
+            let astarte_message_hub_options = options
+                .astarte_message_hub
+                .clone()
+                .expect("Unable to find MessageHub options");
+            let mut dm = edgehog_device_runtime::DeviceManager::new(
+                options,
+                AstarteMessageHubNode::new(astarte_message_hub_options, interfaces_directory)
+                    .await?,
+            )
+            .await?;
+
+            dm.init().await?;
+
+            dm.run().await;
+        }
+    };
 
     Ok(())
 }


### PR DESCRIPTION
~~In the AstarteMessageHubNode struct I used a Mutex instead of RwLock, because the tonic::transport::Streaming is !Sync so it can be shared between threads only using a Mutex (this is an interesting difference between the two).~~

- Separate Astarte Subscriber from Publisher.
- Add Protoc install to CI.

closes #169 