### PR TITLE
fix(dependabot): remove the ignore since this is a binary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,3 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-      ignore:
-          - dependency-name: "*"
-            # patch and minor updates don't matter for libraries
-            # remove this ignore rule if your package has binaries
-            update-types:
-                - "version-update:semver-patch"
-                - "version-update:semver-minor"


### PR DESCRIPTION
The minor and patch updates are worth it for this project since it is a binary. It was my mistake for previously adding the ignore.