### PR TITLE
feat(ci): add vendor workflow

### DIFF
--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -1,0 +1,56 @@
+# This file is part of Edgehog.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: new-release
+permissions:
+  contents: read
+on:
+  release:
+    types: [published]
+jobs:
+  # This workflow on a new release will trigger the vendoring workflow to update the vendored
+  # dependencies in the edgehog-device-runtime-third-party-vendor repository.
+  new-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the release branch
+        id: branch
+        run: |
+          if [[ ! $GITHUB_REF =~ ^refs/tags/v.*$ ]]; then
+            echo "Not a release tag $GITHUB_REF, exptected vx.y.z" >&2
+            exit 1
+          fi
+          tag=$(echo $GITHUB_REF | sed -e 's/refs\/tags\/v//g')
+          echo "$tag"
+          branch="release-$(echo "$tag" | cut -d'.' -f -2)"
+          echo "$branch"
+          echo "release=$branch" >> "$GITHUB_OUTPUT"
+      - name: Trigger the dispatch of vendor
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.VENDOR_TOKEN }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'edgehog-device-runtime-third-party-vendor',
+              workflow_id: 'new-release.yaml',
+              ref: 'main',
+              inputs: {
+                release: '${{ steps.branch.outputs.release }}'
+              }
+            })


### PR DESCRIPTION
Create a workflow that will be triggered on a new release and will trigger the vendoring workflow in the edgehog-device-runtime-third-party-vendor repository.