### PR TITLE
feat(ota): improve tests and make the progress a stream

### DIFF
--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -19,9 +19,9 @@
  */
 
 use async_trait::async_trait;
+use futures::stream::BoxStream;
 #[cfg(test)]
 use mockall::automock;
-use tokio::sync::mpsc::Sender;
 
 use crate::error::DeviceManagerError;
 use crate::ota::rauc::BundleInfo;
@@ -32,12 +32,22 @@ pub(crate) mod ota_handler;
 mod ota_handler_test;
 pub(crate) mod rauc;
 
-/// Provides deploying progress information
-#[derive(Clone, PartialEq, Debug)]
-pub struct DeployingProgress {
+/// Provides deploying progress information.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DeployProgress {
     percentage: i32,
     message: String,
 }
+
+/// Provides the status of the deployment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeployStatus {
+    Progress(DeployProgress),
+    Completed { signal: i32 },
+}
+
+/// Stream of the [`DeployStatus`] events
+pub type ProgressStream = BoxStream<'static, Result<DeployStatus, DeviceManagerError>>;
 
 /// A **trait** required for all SystemUpdate handlers that want to update a system.
 #[cfg_attr(test, automock)]
@@ -49,10 +59,7 @@ pub trait SystemUpdate: Send + Sync {
     async fn operation(&self) -> Result<String, DeviceManagerError>;
     async fn compatible(&self) -> Result<String, DeviceManagerError>;
     async fn boot_slot(&self) -> Result<String, DeviceManagerError>;
-    async fn receive_completed(
-        &self,
-        sender: Sender<DeployingProgress>,
-    ) -> Result<i32, DeviceManagerError>;
+    async fn receive_completed(&self) -> Result<ProgressStream, DeviceManagerError>;
     async fn get_primary(&self) -> Result<String, DeviceManagerError>;
     async fn mark(
         &self,
@@ -92,11 +99,8 @@ pub enum OtaError {
     Canceled,
 }
 
-impl Default for DeployingProgress {
+impl Default for DeployStatus {
     fn default() -> Self {
-        DeployingProgress {
-            percentage: 0,
-            message: "".to_owned(),
-        }
+        DeployStatus::Progress(DeployProgress::default())
     }
 }

--- a/src/ota/ota_handler.rs
+++ b/src/ota/ota_handler.rs
@@ -142,18 +142,24 @@ impl OtaHandler {
         sdk: &impl Publisher,
         data: HashMap<String, AstarteType>,
     ) -> Result<(), DeviceManagerError> {
-        if let AstarteType::String(operation_str) = &data["operation"] {
-            match operation_str.parse::<OtaOperation>() {
-                Ok(OtaOperation::Update) => self.handle_update(sdk, data).await,
-                Ok(OtaOperation::Cancel) => self.handle_cancel(sdk, data).await,
-                Err(_) => Err(DeviceManagerError::OtaError(OtaError::Request(
-                    "Ota operation unsupported",
-                ))),
-            }
-        } else {
-            Err(DeviceManagerError::OtaError(OtaError::Request(
+        let Some(AstarteType::String(operation_str)) = data.get("operation") else {
+            error!("missing ota operation: {:?}", data);
+
+            return Err(DeviceManagerError::OtaError(OtaError::Request(
                 "Ota operation unsupported",
-            )))
+            )));
+        };
+
+        match operation_str.parse() {
+            Ok(OtaOperation::Update) => self.handle_update(sdk, data).await,
+            Ok(OtaOperation::Cancel) => self.handle_cancel(sdk, data).await,
+            Err(()) => {
+                error!("could not parse operation: {}", operation_str);
+
+                Err(DeviceManagerError::OtaError(OtaError::Request(
+                    "Ota operation unsupported",
+                )))
+            }
         }
     }
 
@@ -162,41 +168,57 @@ impl OtaHandler {
         sdk: &impl Publisher,
         data: HashMap<String, AstarteType>,
     ) -> Result<(), DeviceManagerError> {
-        let (ota_status_publisher, mut ota_status_receiver) = mpsc::channel(8);
-        if let AstarteType::String(operation_str) = &data["uuid"] {
-            let uuid = Uuid::parse_str(operation_str).map_err(|_| {
-                DeviceManagerError::OtaError(OtaError::Request("Unable to parse request_uuid"))
-            })?;
+        let Some(AstarteType::String(operation_str)) = data.get("uuid") else {
+            error!("update data missing uuid: {:?}", data);
 
-            self.check_update_already_in_progress(uuid, sdk).await?;
+            return Ok(());
+        };
 
-            let cancel_token = CancellationToken::new();
-            *self.ota_cancellation.write().await = Some(cancel_token.clone());
-            let msg = OtaMessage::HandleOtaEvent {
-                data,
-                cancel_token,
-                respond_to: ota_status_publisher,
-            };
+        let uuid = Uuid::parse_str(operation_str).map_err(|_| {
+            DeviceManagerError::OtaError(OtaError::Request("Unable to parse request_uuid"))
+        })?;
 
-            self.sender.send(msg).await.map_err(|_| {
-                DeviceManagerError::OtaError(OtaError::Internal(
-                    "Unable to execute HandleOtaEvent, receiver channel dropped",
-                ))
-            })?;
+        self.check_update_already_in_progress(uuid, sdk).await?;
 
-            while let Some(ota_status) = ota_status_receiver.recv().await {
-                send_ota_event(sdk, &ota_status).await?;
+        let mut ota_status_receiver = self.start_ota_update(data).await?;
 
-                //After entering in Deploying state the OTA cannot be stopped.
-                if let OtaStatus::Deploying(_, _) = &ota_status {
-                    *self.ota_cancellation.write().await = None;
-                } else if let OtaStatus::Failure(ota_error, _) = ota_status {
-                    *self.ota_cancellation.write().await = None;
-                    return Err(DeviceManagerError::OtaError(ota_error));
-                }
+        while let Some(ota_status) = ota_status_receiver.recv().await {
+            send_ota_event(sdk, &ota_status).await?;
+
+            //After entering in Deploying state the OTA cannot be stopped.
+            if let OtaStatus::Deploying(_, _) = &ota_status {
+                *self.ota_cancellation.write().await = None;
+            } else if let OtaStatus::Failure(ota_error, _) = ota_status {
+                *self.ota_cancellation.write().await = None;
+                return Err(DeviceManagerError::OtaError(ota_error));
             }
         }
         Ok(())
+    }
+
+    /// Sends the cancellation token and channel to start the update process.
+    pub(crate) async fn start_ota_update(
+        &self,
+        data: HashMap<String, AstarteType>,
+    ) -> Result<mpsc::Receiver<OtaStatus>, DeviceManagerError> {
+        let (ota_status_publisher, ota_status_receiver) = mpsc::channel(8);
+
+        let cancel_token = CancellationToken::new();
+        *self.ota_cancellation.write().await = Some(cancel_token.clone());
+
+        let msg = OtaMessage::HandleOtaEvent {
+            data,
+            cancel_token,
+            respond_to: ota_status_publisher,
+        };
+
+        self.sender.send(msg).await.map_err(|_| {
+            DeviceManagerError::OtaError(OtaError::Internal(
+                "Unable to execute HandleOtaEvent, receiver channel dropped",
+            ))
+        })?;
+
+        Ok(ota_status_receiver)
     }
 
     async fn check_update_already_in_progress(
@@ -239,84 +261,83 @@ impl OtaHandler {
         sdk: &impl Publisher,
         data: HashMap<String, AstarteType>,
     ) -> Result<(), DeviceManagerError> {
-        if let AstarteType::String(request_uuid_str) = &data["uuid"] {
-            let request_uuid = Uuid::parse_str(request_uuid_str).map_err(|_| {
-                DeviceManagerError::OtaError(OtaError::Request("Unable to parse request_uuid"))
-            })?;
+        let Some(AstarteType::String(request_uuid_str)) = &data.get("uuid") else {
+            return Err(DeviceManagerError::OtaError(OtaError::Request(
+                "Missing uuid in cancell request data",
+            )));
+        };
 
-            let cancel_ota_request = OtaRequest {
-                uuid: request_uuid,
-                url: "".to_string(),
-            };
+        let request_uuid = Uuid::parse_str(request_uuid_str).map_err(|_| {
+            DeviceManagerError::OtaError(OtaError::Request("Unable to parse request_uuid"))
+        })?;
 
-            let ota_status = match self.get_ota_status().await {
-                Ok(ota_status) => ota_status,
-                Err(err) => {
-                    let message = "Unable to cancel OTA request";
-                    error!("{message} : {err}");
+        let cancel_ota_request = OtaRequest {
+            uuid: request_uuid,
+            url: "".to_string(),
+        };
+
+        let ota_status = match self.get_ota_status().await {
+            Ok(ota_status) => ota_status,
+            Err(err) => {
+                let message = "Unable to cancel OTA request";
+                error!("{message} : {err}");
+                send_ota_event(
+                    sdk,
+                    &OtaStatus::Failure(OtaError::Internal(message), Some(cancel_ota_request)),
+                )
+                .await?;
+
+                return Ok(());
+            }
+        };
+
+        match ota_status.ota_request() {
+            None => {
+                send_ota_event(
+                    sdk,
+                    &OtaStatus::Failure(
+                        OtaError::Internal(
+                            "Unable to cancel OTA request, internal request is empty",
+                        ),
+                        Some(cancel_ota_request),
+                    ),
+                )
+                .await?;
+            }
+            Some(current_ota_request) if cancel_ota_request.uuid != current_ota_request.uuid => {
+                send_ota_event(
+                    sdk,
+                    &OtaStatus::Failure(
+                        OtaError::Internal(
+                            "Unable to cancel OTA request, they have different identifier",
+                        ),
+                        Some(cancel_ota_request),
+                    ),
+                )
+                .await?;
+            }
+            _ => {
+                let mut ota_cancellation = self.ota_cancellation.write().await;
+                if let Some(ota_token) = ota_cancellation.take() {
+                    ota_token.cancel();
                     send_ota_event(
                         sdk,
-                        &OtaStatus::Failure(OtaError::Internal(message), Some(cancel_ota_request)),
+                        &OtaStatus::Failure(OtaError::Canceled, Some(cancel_ota_request)),
                     )
                     .await?;
-
-                    return Ok(());
-                }
-            };
-
-            return match ota_status.ota_request() {
-                None => {
+                } else {
                     send_ota_event(
                         sdk,
                         &OtaStatus::Failure(
-                            OtaError::Internal(
-                                "Unable to cancel OTA request, internal request is empty",
-                            ),
+                            OtaError::Internal("Unable to cancel OTA request"),
                             Some(cancel_ota_request),
                         ),
                     )
-                    .await?;
-
-                    Ok(())
+                    .await?
                 }
-                Some(current_ota_request)
-                    if cancel_ota_request.uuid != current_ota_request.uuid =>
-                {
-                    send_ota_event(
-                        sdk,
-                        &OtaStatus::Failure(
-                            OtaError::Internal(
-                                "Unable to cancel OTA request, they have different identifier",
-                            ),
-                            Some(cancel_ota_request),
-                        ),
-                    )
-                    .await?;
-                    Ok(())
-                }
-                _ => {
-                    let mut ota_cancellation = self.ota_cancellation.write().await;
-                    if let Some(ota_token) = ota_cancellation.take() {
-                        ota_token.cancel();
-                        send_ota_event(
-                            sdk,
-                            &OtaStatus::Failure(OtaError::Canceled, Some(cancel_ota_request)),
-                        )
-                        .await?;
-                    } else {
-                        send_ota_event(
-                            sdk,
-                            &OtaStatus::Failure(
-                                OtaError::Internal("Unable to cancel OTA request"),
-                                Some(cancel_ota_request),
-                            ),
-                        )
-                        .await?
-                    }
-                    Ok(())
-                }
-            };
+            }
         }
+
         Ok(())
     }
 }
@@ -452,7 +473,7 @@ async fn send_ota_event(sdk: &impl Publisher, ota_status: &OtaStatus) -> Result<
 mod tests {
     use crate::ota::ota_handle::{OtaRequest, OtaStatus};
     use crate::ota::ota_handler::OtaEvent;
-    use crate::ota::{DeployingProgress, OtaError};
+    use crate::ota::{DeployProgress, OtaError};
     use uuid::Uuid;
 
     impl Default for OtaRequest {
@@ -534,7 +555,7 @@ mod tests {
 
         let ota_event = OtaEvent::from(&OtaStatus::Deploying(
             ota_request,
-            DeployingProgress::default(),
+            DeployProgress::default(),
         ));
         assert_eq!(expected_ota_event.status, ota_event.status);
         assert_eq!(expected_ota_event.statusCode, ota_event.statusCode);
@@ -556,7 +577,7 @@ mod tests {
 
         let ota_event = OtaEvent::from(&OtaStatus::Deploying(
             ota_request,
-            DeployingProgress {
+            DeployProgress {
                 percentage: 100,
                 message: "done".to_string(),
             },

--- a/src/ota/ota_handler_test.rs
+++ b/src/ota/ota_handler_test.rs
@@ -18,1995 +18,1318 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-    use std::sync::Arc;
-    use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
 
-    use astarte_device_sdk::types::AstarteType;
-    use httpmock::prelude::*;
-    use tokio::sync::{mpsc, RwLock};
-    use uuid::Uuid;
+use astarte_device_sdk::types::AstarteType;
+use futures::StreamExt;
+use httpmock::prelude::*;
+use tokio::sync::{mpsc, RwLock};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
-    use crate::data::MockPublisher;
-    use crate::error::DeviceManagerError;
-    use crate::ota::ota_handle::{run_ota, Ota, PersistentState};
-    use crate::ota::ota_handler::{OtaEvent, OtaHandler};
-    use crate::ota::rauc::BundleInfo;
-    use crate::ota::{MockSystemUpdate, OtaError};
-    use crate::repository::MockStateRepository;
+use crate::data::MockPublisher;
+use crate::error::DeviceManagerError;
+use crate::ota::ota_handle::{run_ota, Ota, OtaRequest, OtaStatus, PersistentState};
+use crate::ota::ota_handler::{OtaEvent, OtaHandler};
+use crate::ota::rauc::BundleInfo;
+use crate::ota::{DeployStatus, MockSystemUpdate, OtaError, ProgressStream};
+use crate::repository::MockStateRepository;
 
-    impl OtaHandler {
-        async fn mock_new(
-            system_update: MockSystemUpdate,
-            state_mock: MockStateRepository<PersistentState>,
-        ) -> Result<Self, DeviceManagerError> {
-            let (sender, receiver) = mpsc::channel(8);
-            let ota = Ota::<MockSystemUpdate, MockStateRepository<PersistentState>>::mock_new(
-                system_update,
-                state_mock,
-            );
-            tokio::spawn(run_ota(ota, receiver));
+pub(crate) fn deploy_status_stream<I>(iter: I) -> Result<ProgressStream, DeviceManagerError>
+where
+    I: IntoIterator<Item = DeployStatus>,
+{
+    Ok(futures::stream::iter(iter.into_iter().map(Ok).collect::<Vec<_>>()).boxed())
+}
 
-            Ok(Self {
-                sender,
-                ota_cancellation: Arc::new(RwLock::new(None)),
-            })
-        }
+impl OtaHandler {
+    fn mock_new(
+        system_update: MockSystemUpdate,
+        state_repository: MockStateRepository<PersistentState>,
+    ) -> Self {
+        let ota = Ota::mock_new(system_update, state_repository);
+
+        Self::mock_new_with_ota(ota)
     }
 
-    #[tokio::test]
-    async fn handle_ota_event_bundle_not_compatible() {
-        let bundle_info = "rauc-demo-x86";
-        let system_info = "rauc-demo-arm";
+    fn mock_new_with_path(
+        system_update: MockSystemUpdate,
+        state_repository: MockStateRepository<PersistentState>,
+    ) -> (Self, tempdir::TempDir) {
+        let (ota, dir) = Ota::mock_new_with_path(system_update, state_repository);
 
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-        state_mock.expect_exists().returning(|| true);
+        let handler = Self::mock_new_with_ota(ota);
 
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: bundle_info.to_string(),
-                version: "1".to_string(),
-            })
-        });
+        (handler, dir)
+    }
 
-        system_update
-            .expect_compatible()
-            .returning(|| Ok(system_info.to_string()));
+    fn mock_new_with_ota(ota: Ota<MockSystemUpdate, MockStateRepository<PersistentState>>) -> Self {
+        let (sender, receiver) = mpsc::channel(8);
 
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
+        tokio::spawn(run_ota(ota, receiver));
 
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
+        Self {
+            sender,
+            ota_cancellation: Arc::new(RwLock::new(None)),
+        }
+    }
+}
 
-        let uuid = Uuid::new_v4();
-        let data = HashMap::from([
-            ("url".to_string(), AstarteType::String(ota_url)),
-            ("uuid".to_string(), AstarteType::String(uuid.to_string())),
-            (
-                "operation".to_string(),
-                AstarteType::String("Update".to_string()),
-            ),
-        ]);
+#[tokio::test]
+async fn handle_ota_event_bundle_not_compatible() {
+    let bundle_info = "rauc-demo-x86";
+    let system_info = "rauc-demo-arm";
 
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_write().returning(|_| Ok(()));
+    state_mock.expect_clear().returning(|| Ok(()));
+    state_mock.expect_exists().returning(|| true);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    let mut system_update = MockSystemUpdate::new();
+    system_update.expect_info().returning(|_: &str| {
+        Ok(BundleInfo {
+            compatible: bundle_info.to_string(),
+            version: "1".to_string(),
+        })
+    });
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 100
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    system_update
+        .expect_compatible()
+        .returning(|| Ok(system_info.to_string()));
 
-        let expected_message = format!(
-            "bundle {} is not compatible with system {system_info}",
-            bundle_info
-        );
-        let expected_message_cp = expected_message.clone();
+    let binary_content = b"\x80\x02\x03";
+    let binary_size = binary_content.len();
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Failure")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-                    && ota_event.statusCode.eq("InvalidBaseImage")
-                    && ota_event.message.eq(&expected_message_cp)
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    let server = MockServer::start();
+    let ota_url = server.url("/ota.bin");
+    let mock_ota_file_request = &server.mock(|when, then| {
+        when.method(GET).path("/ota.bin");
+        then.status(200)
+            .header("content-Length", binary_size.to_string())
+            .body(binary_content);
+    });
 
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let result = ota_handler.ota_event(&publisher, data).await;
-        mock_ota_file_request.assert();
+    let uuid = Uuid::new_v4();
+    let data = HashMap::from([
+        ("url".to_string(), AstarteType::String(ota_url)),
+        ("uuid".to_string(), AstarteType::String(uuid.to_string())),
+        (
+            "operation".to_string(),
+            AstarteType::String("Update".to_string()),
+        ),
+    ]);
 
-        assert!(result.is_err());
-        if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
-            if let OtaError::InvalidBaseImage(error_message) = ota_error {
-                assert_eq!(expected_message.to_string(), error_message)
-            } else {
-                panic!("Wrong OtaError type");
-            }
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Acknowledged")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Downloading")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Downloading")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 100
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
+
+    let expected_message = format!(
+        "bundle {} is not compatible with system {system_info}",
+        bundle_info
+    );
+    let expected_message_cp = expected_message.clone();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event.statusCode.eq("InvalidBaseImage")
+                && ota_event.message.eq(&expected_message_cp)
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
+
+    let (ota_handler, _dir) = OtaHandler::mock_new_with_path(system_update, state_mock);
+    let result = ota_handler.ota_event(&publisher, data).await;
+    mock_ota_file_request.assert();
+
+    assert!(result.is_err());
+    if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
+        if let OtaError::InvalidBaseImage(error_message) = ota_error {
+            assert_eq!(expected_message.to_string(), error_message)
         } else {
-            panic!("Wrong DeviceManagerError type");
+            panic!("Wrong OtaError type");
         }
+    } else {
+        panic!("Wrong DeviceManagerError type");
     }
+}
 
-    #[tokio::test]
-    async fn handle_ota_event_bundle_install_completed_fail() {
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-        state_mock.expect_exists().returning(|| true);
+#[tokio::test]
+async fn handle_ota_event_bundle_install_completed_fail() {
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_write().returning(|_| Ok(()));
+    state_mock.expect_clear().returning(|| Ok(()));
+    state_mock.expect_exists().returning(|| true);
 
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
+    let mut system_update = MockSystemUpdate::new();
+    system_update.expect_info().returning(|_: &str| {
+        Ok(BundleInfo {
+            compatible: "rauc-demo-x86".to_string(),
+            version: "1".to_string(),
+        })
+    });
 
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(-1));
-        system_update.expect_install_bundle().returning(|_| Ok(()));
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("".to_owned()));
-        system_update
-            .expect_last_error()
-            .returning(|| Ok("Unable to deploy image".to_string()));
+    system_update
+        .expect_compatible()
+        .returning(|| Ok("rauc-demo-x86".to_string()));
+    system_update
+        .expect_operation()
+        .returning(|| Ok("".to_string()));
+    system_update
+        .expect_receive_completed()
+        .returning(|| deploy_status_stream([DeployStatus::Completed { signal: -1 }]));
+    system_update.expect_install_bundle().returning(|_| Ok(()));
+    system_update
+        .expect_boot_slot()
+        .returning(|| Ok("".to_owned()));
+    system_update
+        .expect_last_error()
+        .returning(|| Ok("Unable to deploy image".to_string()));
 
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
+    let binary_content = b"\x80\x02\x03";
+    let binary_size = binary_content.len();
 
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
+    let server = MockServer::start();
+    let ota_url = server.url("/ota.bin");
+    let mock_ota_file_request = &server.mock(|when, then| {
+        when.method(GET).path("/ota.bin");
+        then.status(200)
+            .header("content-Length", binary_size.to_string())
+            .body(binary_content);
+    });
 
-        let uuid = Uuid::new_v4();
-        let data = HashMap::from([
-            ("url".to_string(), AstarteType::String(ota_url)),
-            ("uuid".to_string(), AstarteType::String(uuid.to_string())),
-            (
-                "operation".to_string(),
-                AstarteType::String("Update".to_string()),
-            ),
-        ]);
+    let uuid = Uuid::new_v4();
+    let data = HashMap::from([
+        ("url".to_string(), AstarteType::String(ota_url)),
+        ("uuid".to_string(), AstarteType::String(uuid.to_string())),
+        (
+            "operation".to_string(),
+            AstarteType::String("Update".to_string()),
+        ),
+    ]);
 
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Acknowledged")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Downloading")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 100
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Downloading")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 100
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deploying")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Deploying")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        let expected_message = "Update failed with signal -1".to_string();
-        let expected_message_cl = expected_message.clone();
+    let expected_message = "Update failed with signal -1".to_string();
+    let expected_message_cl = expected_message.clone();
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Failure")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-                    && ota_event.statusCode.eq("InvalidBaseImage")
-                    && ota_event.message.eq(&expected_message_cl)
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event.statusCode.eq("InvalidBaseImage")
+                && ota_event.message.eq(&expected_message_cl)
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let result = ota_handler.ota_event(&publisher, data).await;
-        mock_ota_file_request.assert();
+    let (ota_handler, _dir) = OtaHandler::mock_new_with_path(system_update, state_mock);
+    let result = ota_handler.ota_event(&publisher, data).await;
+    mock_ota_file_request.assert();
 
-        assert!(result.is_err());
+    assert!(result.is_err());
 
-        if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
-            if let OtaError::InvalidBaseImage(error_message) = ota_error {
-                assert_eq!(expected_message, error_message)
-            } else {
-                panic!("Wrong OtaError type");
-            }
+    if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
+        if let OtaError::InvalidBaseImage(error_message) = ota_error {
+            assert_eq!(expected_message, error_message)
         } else {
-            panic!("Wrong DeviceManagerError type");
+            panic!("Wrong OtaError type");
         }
+    } else {
+        panic!("Wrong DeviceManagerError type");
     }
+}
 
-    #[tokio::test]
-    async fn ota_event_fail_deployed() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
+#[tokio::test]
+async fn ota_event_fail_deployed() {
+    let uuid = Uuid::new_v4();
+    let slot = "A";
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_exists().returning(|| true);
+    state_mock.expect_read().returning(move || {
+        Ok(PersistentState {
+            uuid,
+            slot: slot.to_owned(),
+        })
+    });
+    state_mock.expect_write().returning(|_| Ok(()));
+    state_mock.expect_clear().returning(|| Ok(()));
 
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
+    let mut system_update = MockSystemUpdate::new();
+    system_update.expect_info().returning(|_: &str| {
+        Ok(BundleInfo {
+            compatible: "rauc-demo-x86".to_string(),
+            version: "1".to_string(),
+        })
+    });
 
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
+    system_update
+        .expect_compatible()
+        .returning(|| Ok("rauc-demo-x86".to_string()));
 
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_| Err(DeviceManagerError::FatalError("install fail".to_string())));
+    system_update
+        .expect_boot_slot()
+        .returning(|| Ok("B".to_owned()));
+    system_update
+        .expect_install_bundle()
+        .returning(|_| Err(DeviceManagerError::FatalError("install fail".to_string())));
 
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
+    let binary_content = b"\x80\x02\x03";
+    let binary_size = binary_content.len();
 
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
+    let server = MockServer::start();
+    let ota_url = server.url("/ota.bin");
+    let mock_ota_file_request = &server.mock(|when, then| {
+        when.method(GET).path("/ota.bin");
+        then.status(200)
+            .header("content-Length", binary_size.to_string())
+            .body(binary_content);
+    });
 
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Update".to_string()),
+    );
 
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Acknowledged")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Downloading")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 100
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Downloading")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 100
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deploying")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Deploying")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Failure")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-                    && ota_event.statusCode.eq("InvalidBaseImage")
-                    && ota_event.message.eq("Unable to install ota image")
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event.statusCode.eq("InvalidBaseImage")
+                && ota_event.message.eq("Unable to install ota image")
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
+    let (ota_handler, _dir) = OtaHandler::mock_new_with_path(system_update, state_mock);
+    let result = ota_handler.ota_event(&publisher, ota_req_map).await;
+    mock_ota_file_request.assert();
 
-        assert!(result.is_err());
-        if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
-            if let OtaError::InvalidBaseImage(error_message) = ota_error {
-                assert_eq!("Unable to install ota image".to_string(), error_message)
-            } else {
-                panic!("Wrong OtaError type");
-            }
+    assert!(result.is_err());
+    if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
+        if let OtaError::InvalidBaseImage(error_message) = ota_error {
+            assert_eq!("Unable to install ota image".to_string(), error_message)
         } else {
-            panic!("Wrong DeviceManagerError type");
+            panic!("Wrong OtaError type");
         }
+    } else {
+        panic!("Wrong DeviceManagerError type");
     }
+}
 
-    #[tokio::test]
-    async fn ota_event_update_success() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
+#[tokio::test]
+async fn ota_event_update_success() {
+    let uuid = Uuid::new_v4();
+    let slot = "A";
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_exists().returning(|| true);
+    state_mock.expect_read().returning(move || {
+        Ok(PersistentState {
+            uuid,
+            slot: slot.to_owned(),
+        })
+    });
+    state_mock.expect_write().returning(|_| Ok(()));
+    state_mock.expect_clear().returning(|| Ok(()));
 
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
+    let mut system_update = MockSystemUpdate::new();
+    system_update.expect_info().returning(|_: &str| {
+        Ok(BundleInfo {
+            compatible: "rauc-demo-x86".to_string(),
+            version: "1".to_string(),
+        })
+    });
 
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
+    system_update
+        .expect_compatible()
+        .returning(|| Ok("rauc-demo-x86".to_string()));
 
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .once()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
+    system_update
+        .expect_boot_slot()
+        .returning(|| Ok("B".to_owned()));
+    system_update
+        .expect_install_bundle()
+        .returning(|_: &str| Ok(()));
+    system_update
+        .expect_operation()
+        .returning(|| Ok("".to_string()));
+    system_update
+        .expect_receive_completed()
+        .once()
+        .returning(|| deploy_status_stream([DeployStatus::Completed { signal: 0 }]));
+    system_update
+        .expect_get_primary()
+        .returning(|| Ok("rootfs.0".to_owned()));
+    system_update.expect_mark().returning(|_: &str, _: &str| {
+        Ok((
+            "rootfs.0".to_owned(),
+            "marked slot rootfs.0 as good".to_owned(),
+        ))
+    });
 
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
+    let binary_content = b"\x80\x02\x03";
+    let binary_size = binary_content.len();
 
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
+    let server = MockServer::start();
+    let ota_url = server.url("/ota.bin");
+    let mock_ota_file_request = &server.mock(|when, then| {
+        when.method(GET).path("/ota.bin");
+        then.status(200)
+            .header("content-Length", binary_size.to_string())
+            .body(binary_content);
+    });
 
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Update".to_string()),
+    );
 
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
 
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Acknowledged")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Downloading")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Downloading")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 100
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Deploying")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Deployed")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Rebooting")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Success")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn ota_event_update_already_in_progress_same_uuid() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
-
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
-
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
-
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .delay(Duration::from_secs(3))
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Acknowledged")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Downloading")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Downloading")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 100
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deploying")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Deploying")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deployed")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Deployed")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Rebooting")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Rebooting")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Success")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Success")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let ota_handler_cp = ota_handler.clone();
+    let (ota_handler, _dir) = OtaHandler::mock_new_with_path(system_update, state_mock);
+    let result = ota_handler.ota_event(&publisher, ota_req_map).await;
+    mock_ota_file_request.assert();
+    assert!(result.is_ok());
+}
 
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            let mut ota_req_map = HashMap::new();
-            ota_req_map.insert(
-                "uuid".to_owned(),
-                AstarteType::String(uuid.clone().to_string()),
-            );
-            ota_req_map.insert(
-                "operation".to_string(),
-                AstarteType::String("Update".to_string()),
-            );
+#[tokio::test]
+async fn ota_event_update_already_in_progress_same_uuid() {
+    let uuid = Uuid::new_v4();
 
-            let mut publisher = MockPublisher::new();
+    let state_mock = MockStateRepository::<PersistentState>::new();
 
-            publisher
-                .expect_send_object()
-                .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                    ota_event.status.eq("Downloading")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                        && ota_event.message.eq("")
-                })
-                .once()
-                .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+    let system_update = MockSystemUpdate::new();
 
-            let result = ota_handler_cp.ota_event(&publisher, ota_req_map).await;
-            assert!(result.is_err());
+    let ota_url = "http://localhost".to_string();
 
-            if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
-                assert_eq!(ota_error, OtaError::UpdateAlreadyInProgress)
-            } else {
-                panic!("Wrong DeviceManagerError type");
-            }
-        });
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url.clone()));
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Update".to_string()),
+    );
 
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
 
-        assert!(result.is_ok());
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Acknowledged")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        let result = handle.await;
-        assert!(result.is_ok());
-    }
+    let ota = Ota::mock_new(system_update, state_mock);
+    // Fake another update is happening state != idle
+    *ota.ota_status.write().await = OtaStatus::Acknowledged(OtaRequest { uuid, url: ota_url });
 
-    #[tokio::test]
-    async fn ota_event_update_already_in_progress_different_uuid() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
+    let ota_handler = OtaHandler::mock_new_with_ota(ota);
+
+    let err = ota_handler
+        .ota_event(&publisher, ota_req_map)
+        .await
+        .expect_err("expected already in progress error");
+
+    assert!(
+        matches!(
+            err,
+            DeviceManagerError::OtaError(OtaError::UpdateAlreadyInProgress)
+        ),
+        "expected error for update already in progress but got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn ota_event_update_already_in_progress_different_uuid() {
+    let uuid_1 = Uuid::new_v4();
+    let uuid_2 = Uuid::new_v4();
+
+    let state_mock = MockStateRepository::<PersistentState>::new();
+
+    let system_update = MockSystemUpdate::new();
+
+    let ota_url = "http://localhost".to_string();
+
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url.clone()));
+    ota_req_map.insert("uuid".to_owned(), AstarteType::String(uuid_1.to_string()));
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Update".to_string()),
+    );
+
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusCode.eq("UpdateAlreadyInProgress")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid_1.to_string()
+                && ota_event.message.eq("")
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
+
+    let ota = Ota::mock_new(system_update, state_mock);
+    // Fake another update is happening state != idle
+    *ota.ota_status.write().await = OtaStatus::Acknowledged(OtaRequest {
+        uuid: uuid_2,
+        url: ota_url,
+    });
+
+    let ota_handler = OtaHandler::mock_new_with_ota(ota);
+
+    let err = ota_handler
+        .ota_event(&publisher, ota_req_map)
+        .await
+        .expect_err("expected already in progress error");
+
+    assert!(
+        matches!(
+            err,
+            DeviceManagerError::OtaError(OtaError::UpdateAlreadyInProgress)
+        ),
+        "expected error for update already in progress but got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn ota_event_canceled() {
+    let uuid = Uuid::new_v4();
+    let cancel_token = CancellationToken::new();
+
+    let state_repository = MockStateRepository::<PersistentState>::new();
+    let system_update = MockSystemUpdate::new();
+
+    let ota = Ota::mock_new(system_update, state_repository);
+    *ota.ota_status.write().await = OtaStatus::Acknowledged(OtaRequest {
+        uuid,
+        url: "".to_string(),
+    });
+
+    let ota_handler = OtaHandler::mock_new_with_ota(ota);
+    *ota_handler.ota_cancellation.write().await = Some(cancel_token.clone());
+
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Cancel".to_string()),
+    );
+
+    let mut publisher = MockPublisher::new();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusCode.eq("Canceled")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+
+    let res = ota_handler.ota_event(&publisher, ota_req_map).await;
+
+    assert!(res.is_ok(), "ota cancel failed with: {}", res.unwrap_err());
+
+    assert!(cancel_token.is_cancelled());
+}
+
+#[tokio::test]
+async fn ota_event_success_after_canceled_event() {
+    let uuid = Uuid::new_v4();
+    let slot = "A";
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_exists().returning(|| true);
+    state_mock.expect_read().returning(move || {
+        Ok(PersistentState {
+            uuid,
+            slot: slot.to_owned(),
+        })
+    });
+    state_mock.expect_write().returning(|_| Ok(()));
+    state_mock.expect_clear().returning(|| Ok(()));
+
+    let mut system_update = MockSystemUpdate::new();
+    system_update.expect_info().returning(|_: &str| {
+        Ok(BundleInfo {
+            compatible: "rauc-demo-x86".to_string(),
+            version: "1".to_string(),
+        })
+    });
+
+    system_update
+        .expect_compatible()
+        .returning(|| Ok("rauc-demo-x86".to_string()));
+
+    system_update
+        .expect_boot_slot()
+        .returning(|| Ok("B".to_owned()));
+    system_update
+        .expect_install_bundle()
+        .returning(|_: &str| Ok(()));
+    system_update
+        .expect_operation()
+        .returning(|| Ok("".to_string()));
+    system_update
+        .expect_receive_completed()
+        .returning(|| deploy_status_stream([DeployStatus::Completed { signal: 0 }]));
+    system_update
+        .expect_get_primary()
+        .returning(|| Ok("rootfs.0".to_owned()));
+    system_update.expect_mark().returning(|_: &str, _: &str| {
+        Ok((
+            "rootfs.0".to_owned(),
+            "marked slot rootfs.0 as good".to_owned(),
+        ))
+    });
+
+    let binary_content = b"\x80\x02\x03";
+    let binary_size = binary_content.len();
+
+    let server = MockServer::start();
+    let ota_url = server.url("/ota.bin");
+    let mock_ota_file_request = &server.mock(|when, then| {
+        when.method(GET).path("/ota.bin");
+        then.status(200)
+            .header("content-Length", binary_size.to_string())
+            .body(binary_content);
+    });
+
+    let mut ota_update = HashMap::new();
+    ota_update.insert("url".to_owned(), AstarteType::String(ota_url.clone()));
+    ota_update.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_update.insert(
+        "operation".to_string(),
+        AstarteType::String("Update".to_string()),
+    );
+
+    let (ota_handler, _dir) = OtaHandler::mock_new_with_path(system_update, state_mock);
+
+    // Start the update but handle the flow, so we can cancel it.
+    let mut rx_update = ota_handler
+        .start_ota_update(ota_update)
+        .await
+        .expect("failed to start ota");
+
+    let ack = rx_update.recv().await.expect("failed to receive ack");
+    assert_eq!(
+        ack,
+        OtaStatus::Acknowledged(OtaRequest {
+            uuid,
+            url: ota_url.clone()
+        })
+    );
+
+    // We send the cancel event in another thread and wait for the response
+    let mut ota_cancell = HashMap::new();
+    ota_cancell.insert("uuid".to_owned(), AstarteType::String(uuid.to_string()));
+    ota_cancell.insert(
+        "operation".to_string(),
+        AstarteType::String("Cancel".to_string()),
+    );
+
+    let mut publisher = MockPublisher::new();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusCode.eq("Canceled")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+
+    let ota_handler_cl = ota_handler.clone();
+    let cancel_handle =
+        tokio::spawn(async move { ota_handler_cl.ota_event(&publisher, ota_cancell).await });
+
+    // Receive the next OTA event
+    let status = rx_update.recv().await.expect("ota should be downloading");
+    assert_eq!(
+        status,
+        OtaStatus::Downloading(
+            OtaRequest {
                 uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
+                url: ota_url.clone()
+            },
+            0
+        )
+    );
+    let status = rx_update.recv().await;
+    assert!(status.is_none(), "ota should be cancelled");
 
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
+    // Join with the cancel
+    cancel_handle
+        .await
+        .expect("failed to join")
+        .expect("cancel ota successfully");
 
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
+    let mut ota_update = HashMap::new();
+    ota_update.insert("url".to_owned(), AstarteType::String(ota_url));
+    ota_update.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_update.insert(
+        "operation".to_string(),
+        AstarteType::String("Update".to_string()),
+    );
 
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
 
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .delay(Duration::from_secs(3))
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Acknowledged")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Downloading")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Downloading")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 100
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deploying")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Deploying")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deployed")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Deployed")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Rebooting")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Rebooting")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Success")
+    publisher
+        .expect_send_object()
+        .withf(
+            move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
+                interface_name.eq("io.edgehog.devicemanager.OTAEvent")
+                    && path.eq("/event")
+                    && ota_event.status.eq("Success")
                     && ota_event.statusCode.eq("")
                     && ota_event.statusProgress == 0
                     && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let ota_handler_cp = ota_handler.clone();
-
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-
-            let uuid = Uuid::new_v4();
-            let mut ota_req_map = HashMap::new();
-            ota_req_map.insert(
-                "uuid".to_owned(),
-                AstarteType::String(uuid.clone().to_string()),
-            );
-            ota_req_map.insert(
-                "operation".to_string(),
-                AstarteType::String("Update".to_string()),
-            );
-
-            let mut publisher = MockPublisher::new();
-
-            publisher
-                .expect_send_object()
-                .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                    ota_event.status.eq("Failure")
-                        && ota_event.statusCode.eq("UpdateAlreadyInProgress")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                        && ota_event.message.eq("")
-                })
-                .once()
-                .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
-
-            let result = ota_handler_cp.ota_event(&publisher, ota_req_map).await;
-            assert!(result.is_err());
-
-            if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
-                assert_eq!(ota_error, OtaError::UpdateAlreadyInProgress)
-            } else {
-                panic!("Wrong DeviceManagerError type");
-            }
-        });
-
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-
-        assert!(result.is_ok());
-
-        let result = handle.await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn ota_event_canceled() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
-
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
-
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
-
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .delay(Duration::from_secs(5))
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-
-        let ota_handler_cp = ota_handler.clone();
-        let cancel_handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            let mut ota_req_map = HashMap::new();
-            ota_req_map.insert(
-                "uuid".to_owned(),
-                AstarteType::String(uuid.clone().to_string()),
-            );
-            ota_req_map.insert(
-                "operation".to_string(),
-                AstarteType::String("Cancel".to_string()),
-            );
-
-            let mut publisher = MockPublisher::new();
-
-            publisher
-                .expect_send_object()
-                .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                    ota_event.status.eq("Failure")
-                        && ota_event.statusCode.eq("Canceled")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                })
-                .once()
-                .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
-
-            let result = ota_handler_cp.ota_event(&publisher, ota_req_map).await;
-            assert!(result.is_ok());
-        });
-
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-        assert!(result.is_ok());
-
-        let result = cancel_handle.await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn ota_event_success_after_canceled_event() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
-
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
-
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
-
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .delay(Duration::from_secs(5))
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-
-        let ota_handler_cp = ota_handler.clone();
-        let cancel_handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            let mut ota_req_map = HashMap::new();
-            ota_req_map.insert(
-                "uuid".to_owned(),
-                AstarteType::String(uuid.clone().to_string()),
-            );
-            ota_req_map.insert(
-                "operation".to_string(),
-                AstarteType::String("Cancel".to_string()),
-            );
-
-            let mut publisher = MockPublisher::new();
-
-            publisher
-                .expect_send_object()
-                .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                    ota_event.status.eq("Failure")
-                        && ota_event.statusCode.eq("Canceled")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                })
-                .once()
-                .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
-
-            let result = ota_handler_cp.ota_event(&publisher, ota_req_map).await;
-            assert!(result.is_ok());
-        });
-
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-        assert!(result.is_ok());
-
-        let result = cancel_handle.await;
-        assert!(result.is_ok());
-
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Acknowledged")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Downloading")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Downloading")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 100
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Deploying")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Deployed")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Rebooting")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(
-                move |interface_name: &str, path: &str, ota_event: &OtaEvent| {
-                    interface_name.eq("io.edgehog.devicemanager.OTAEvent")
-                        && path.eq("/event")
-                        && ota_event.status.eq("Success")
-                        && ota_event.statusCode.eq("")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                },
-            )
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn ota_event_not_canceled() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
-
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
-
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
-
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 100
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deploying")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deployed")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Rebooting")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Success")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let ota_handler_cp = ota_handler.clone();
-
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            let mut ota_req_map = HashMap::new();
-            ota_req_map.insert(
-                "uuid".to_owned(),
-                AstarteType::String(uuid.clone().to_string()),
-            );
-            ota_req_map.insert(
-                "operation".to_string(),
-                AstarteType::String("Cancel".to_string()),
-            );
-
-            let mut publisher = MockPublisher::new();
-
-            publisher
-                .expect_send_object()
-                .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                    ota_event.status.eq("Failure")
-                        && ota_event.statusCode.eq("InternalError")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid.to_string()
-                        && ota_event.message.eq("Unable to cancel OTA request")
-                })
-                .once()
-                .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
-
-            let result = ota_handler_cp.ota_event(&publisher, ota_req_map).await;
-            assert!(result.is_ok());
-        });
-
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-
-        assert!(result.is_ok());
-
-        let result = handle.await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn ota_event_not_canceled_different_uuid() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
-
-        let mut system_update = MockSystemUpdate::new();
-        system_update.expect_info().returning(|_: &str| {
-            Ok(BundleInfo {
-                compatible: "rauc-demo-x86".to_string(),
-                version: "1".to_string(),
-            })
-        });
-
-        system_update
-            .expect_compatible()
-            .returning(|| Ok("rauc-demo-x86".to_string()));
-
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_install_bundle()
-            .returning(|_: &str| Ok(()));
-        system_update
-            .expect_operation()
-            .returning(|| Ok("".to_string()));
-        system_update
-            .expect_receive_completed()
-            .returning(|_| Ok(0));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
-
-        let binary_content = b"\x80\x02\x03";
-        let binary_size = binary_content.len();
-
-        let server = MockServer::start();
-        let ota_url = server.url("/ota.bin");
-        let mock_ota_file_request = &server.mock(|when, then| {
-            when.method(GET).path("/ota.bin");
-            then.status(200)
-                .delay(Duration::from_secs(5))
-                .header("content-Length", binary_size.to_string())
-                .body(binary_content);
-        });
-
-        let mut ota_req_map = HashMap::new();
-        ota_req_map.insert("url".to_owned(), AstarteType::String(ota_url));
-        ota_req_map.insert(
-            "uuid".to_owned(),
-            AstarteType::String(uuid.clone().to_string()),
-        );
-        ota_req_map.insert(
-            "operation".to_string(),
-            AstarteType::String("Update".to_string()),
-        );
-
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Acknowledged")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Downloading")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 100
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deploying")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Deployed")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Rebooting")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Success")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let ota_handler_cp = ota_handler.clone();
-
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            let mut ota_req_map = HashMap::new();
-            let uuid_diff = Uuid::new_v4();
-            ota_req_map.insert(
-                "uuid".to_owned(),
-                AstarteType::String(uuid_diff.clone().to_string()),
-            );
-            ota_req_map.insert(
-                "operation".to_string(),
-                AstarteType::String("Cancel".to_string()),
-            );
-
-            let mut publisher = MockPublisher::new();
-
-            publisher
-                .expect_send_object()
-                .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                    ota_event.status.eq("Failure")
-                        && ota_event.statusCode.eq("InternalError")
-                        && ota_event.statusProgress == 0
-                        && ota_event.requestUUID == uuid_diff.to_string()
-                        && ota_event
-                            .message
-                            .eq("Unable to cancel OTA request, they have different identifier")
-                })
-                .once()
-                .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
-
-            let result = ota_handler_cp.ota_event(&publisher, ota_req_map).await;
-            assert!(result.is_ok());
-        });
-
-        let result = ota_handler.ota_event(&publisher, ota_req_map).await;
-        mock_ota_file_request.assert();
-
-        assert!(result.is_ok());
-
-        let result = handle.await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn ensure_pending_ota_ota_is_done_fail() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-
-        state_mock.expect_clear().returning(|| Ok(()));
-
-        let mut system_update = MockSystemUpdate::new();
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("A".to_owned()));
-
-        let mut publisher = MockPublisher::new();
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Failure")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-                    && ota_event.statusCode.eq("SystemRollback")
-                    && ota_event.message.eq("Unable to switch slot")
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
-
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let result = ota_handler.ensure_pending_ota_is_done(&publisher).await;
-        assert!(result.is_err());
-
-        if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
-            if let OtaError::SystemRollback(error_message) = ota_error {
-                assert_eq!("Unable to switch slot", error_message)
-            } else {
-                panic!("Wrong OtaError type");
-            }
+            },
+        )
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
+
+    let result = ota_handler.ota_event(&publisher, ota_update).await;
+    assert!(result.is_ok(), "update should succeed");
+
+    // One for the cancelled and one for the successful
+    mock_ota_file_request.assert_hits(2);
+}
+
+/// Try to cancel an OTA without a cancel token (OTA finished, same uuid)
+#[tokio::test]
+async fn ota_event_not_canceled() {
+    let uuid = Uuid::new_v4();
+
+    let state_mock = MockStateRepository::<PersistentState>::new();
+    let system_update = MockSystemUpdate::new();
+
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Cancel".to_string()),
+    );
+
+    let mut publisher = MockPublisher::new();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusCode.eq("InternalError")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event.message.eq("Unable to cancel OTA request")
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+
+    let (ota, _dir) = Ota::mock_new_with_path(system_update, state_mock);
+    *ota.ota_status.write().await = OtaStatus::Success(OtaRequest {
+        uuid,
+        url: "".to_string(),
+    });
+    let ota_handler = OtaHandler::mock_new_with_ota(ota);
+
+    let result = ota_handler.ota_event(&publisher, ota_req_map).await;
+
+    assert!(
+        result.is_ok(),
+        "expected ota event to be Ok, but got: {}",
+        result.unwrap_err()
+    );
+}
+
+/// Try to cancel an OTA without a cancel token (no OTA started)
+#[tokio::test]
+async fn ota_event_not_canceled_empty() {
+    let uuid = Uuid::new_v4();
+
+    let state_mock = MockStateRepository::<PersistentState>::new();
+    let system_update = MockSystemUpdate::new();
+
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Cancel".to_string()),
+    );
+
+    let mut publisher = MockPublisher::new();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusCode.eq("InternalError")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event
+                    .message
+                    .eq("Unable to cancel OTA request, internal request is empty")
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+
+    let (ota_handler, _dir) = OtaHandler::mock_new_with_path(system_update, state_mock);
+
+    let result = ota_handler.ota_event(&publisher, ota_req_map).await;
+
+    assert!(
+        result.is_ok(),
+        "expected ota event to be Ok, but got: {}",
+        result.unwrap_err()
+    );
+}
+
+#[tokio::test]
+async fn ota_event_not_canceled_different_uuid() {
+    let uuid = Uuid::new_v4();
+    let uuid_2 = Uuid::new_v4();
+
+    let state_mock = MockStateRepository::<PersistentState>::new();
+    let system_update = MockSystemUpdate::new();
+
+    let mut ota_req_map = HashMap::new();
+    ota_req_map.insert(
+        "uuid".to_owned(),
+        AstarteType::String(uuid.clone().to_string()),
+    );
+    ota_req_map.insert(
+        "operation".to_string(),
+        AstarteType::String("Cancel".to_string()),
+    );
+
+    let mut publisher = MockPublisher::new();
+
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusCode.eq("InternalError")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event
+                    .message
+                    .eq("Unable to cancel OTA request, they have different identifier")
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+
+    let (ota, _dir) = Ota::mock_new_with_path(system_update, state_mock);
+    *ota.ota_status.write().await = OtaStatus::Deployed(OtaRequest {
+        uuid: uuid_2,
+        url: "".to_string(),
+    });
+    let ota_handler = OtaHandler::mock_new_with_ota(ota);
+
+    let result = ota_handler.ota_event(&publisher, ota_req_map).await;
+
+    assert!(
+        result.is_ok(),
+        "expected ota event to be Ok, but got: {}",
+        result.unwrap_err()
+    );
+}
+
+#[tokio::test]
+async fn ensure_pending_ota_ota_is_done_fail() {
+    let uuid = Uuid::new_v4();
+    let slot = "A";
+
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_exists().returning(|| true);
+    state_mock.expect_read().returning(move || {
+        Ok(PersistentState {
+            uuid,
+            slot: slot.to_owned(),
+        })
+    });
+
+    state_mock.expect_clear().returning(|| Ok(()));
+
+    let mut system_update = MockSystemUpdate::new();
+    system_update
+        .expect_boot_slot()
+        .returning(|| Ok("A".to_owned()));
+
+    let mut publisher = MockPublisher::new();
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Failure")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+                && ota_event.statusCode.eq("SystemRollback")
+                && ota_event.message.eq("Unable to switch slot")
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()));
+
+    let ota_handler = OtaHandler::mock_new(system_update, state_mock);
+    let result = ota_handler.ensure_pending_ota_is_done(&publisher).await;
+    assert!(result.is_err());
+
+    if let DeviceManagerError::OtaError(ota_error) = result.err().unwrap() {
+        if let OtaError::SystemRollback(error_message) = ota_error {
+            assert_eq!("Unable to switch slot", error_message)
         } else {
-            panic!("Wrong DeviceManagerError type");
+            panic!("Wrong OtaError type");
         }
+    } else {
+        panic!("Wrong DeviceManagerError type");
     }
+}
 
-    #[tokio::test]
-    async fn ensure_pending_ota_is_done_ota_success() {
-        let uuid = Uuid::new_v4();
-        let slot = "A";
-        let mut state_mock = MockStateRepository::<PersistentState>::new();
-        state_mock.expect_exists().returning(|| true);
-        state_mock.expect_read().returning(move || {
-            Ok(PersistentState {
-                uuid,
-                slot: slot.to_owned(),
-            })
-        });
-        state_mock.expect_write().returning(|_| Ok(()));
-        state_mock.expect_clear().returning(|| Ok(()));
+#[tokio::test]
+async fn ensure_pending_ota_is_done_ota_success() {
+    let uuid = Uuid::new_v4();
+    let slot = "A";
+    let mut state_mock = MockStateRepository::<PersistentState>::new();
+    state_mock.expect_exists().returning(|| true);
+    state_mock.expect_read().returning(move || {
+        Ok(PersistentState {
+            uuid,
+            slot: slot.to_owned(),
+        })
+    });
+    state_mock.expect_write().returning(|_| Ok(()));
+    state_mock.expect_clear().returning(|| Ok(()));
 
-        let mut system_update = MockSystemUpdate::new();
-        system_update
-            .expect_boot_slot()
-            .returning(|| Ok("B".to_owned()));
-        system_update
-            .expect_get_primary()
-            .returning(|| Ok("rootfs.0".to_owned()));
-        system_update.expect_mark().returning(|_: &str, _: &str| {
-            Ok((
-                "rootfs.0".to_owned(),
-                "marked slot rootfs.0 as good".to_owned(),
-            ))
-        });
+    let mut system_update = MockSystemUpdate::new();
+    system_update
+        .expect_boot_slot()
+        .returning(|| Ok("B".to_owned()));
+    system_update
+        .expect_get_primary()
+        .returning(|| Ok("rootfs.0".to_owned()));
+    system_update.expect_mark().returning(|_: &str, _: &str| {
+        Ok((
+            "rootfs.0".to_owned(),
+            "marked slot rootfs.0 as good".to_owned(),
+        ))
+    });
 
-        let mut publisher = MockPublisher::new();
-        let mut seq = mockall::Sequence::new();
+    let mut publisher = MockPublisher::new();
+    let mut seq = mockall::Sequence::new();
 
-        publisher
-            .expect_send_object()
-            .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
-                ota_event.status.eq("Success")
-                    && ota_event.statusCode.eq("")
-                    && ota_event.statusProgress == 0
-                    && ota_event.requestUUID == uuid.to_string()
-            })
-            .once()
-            .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
-            .in_sequence(&mut seq);
+    publisher
+        .expect_send_object()
+        .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
+            ota_event.status.eq("Success")
+                && ota_event.statusCode.eq("")
+                && ota_event.statusProgress == 0
+                && ota_event.requestUUID == uuid.to_string()
+        })
+        .once()
+        .returning(|_: &str, _: &str, _: OtaEvent| Ok(()))
+        .in_sequence(&mut seq);
 
-        let ota_handler = OtaHandler::mock_new(system_update, state_mock)
-            .await
-            .unwrap();
-        let result = ota_handler.ensure_pending_ota_is_done(&publisher).await;
+    let ota_handler = OtaHandler::mock_new(system_update, state_mock);
+    let result = ota_handler.ensure_pending_ota_is_done(&publisher).await;
 
-        assert!(result.is_ok());
-    }
+    assert!(result.is_ok());
 }

--- a/src/power_management.rs
+++ b/src/power_management.rs
@@ -18,11 +18,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use log::{error, info};
+use std::time::Duration;
+
+use log::{debug, error, info};
 
 use crate::error::DeviceManagerError;
 
 pub async fn reboot() -> Result<(), DeviceManagerError> {
+    debug!("waiting 5 secs before reboot");
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
     if std::env::var("DM_NO_REBOOT").is_ok() {
         info!("Dry run, exiting");
 


### PR DESCRIPTION
Remove the delays and channels from the tests. Replace the test that require to receive a channel as "expect" and make it return a progress stream directly.