### PR TITLE
feat(ws): implement websocket over websocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,13 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# RustRover IDE
 .idea/
+
 /telemetry.json
+
+# GitHub actions checks before committing
 /.pre-commit-config.yaml
+
+# Local coverage file
 tarpaulin-report.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "edgehog-device-runtime-forwarder",
+ "env_logger",
  "tokio",
  "tracing",
 ]
@@ -1215,7 +1216,6 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,20 +97,20 @@ checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -180,7 +180,7 @@ dependencies = [
  "once_cell",
  "p384",
  "rand_core 0.6.4",
- "reqwest 0.11.25",
+ "reqwest 0.11.24",
  "rumqttc",
  "rustls 0.20.9",
  "rustls-native-certs 0.6.3",
@@ -287,7 +287,7 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.2.0",
  "async-executor",
- "async-io 2.3.2",
+ "async-io 2.3.1",
  "async-lock 3.3.0",
  "blocking",
  "futures-lite 2.2.0",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
 dependencies = [
  "async-lock 3.3.0",
  "cfg-if",
@@ -396,7 +396,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io 2.3.2",
+ "async-io 2.3.1",
  "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
@@ -492,11 +492,11 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atomic-write-file"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8204db279bf648d64fe845bd8840f78b39c8132ed4d6a4194c3b10d4b4cfb0b"
+checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
 dependencies = [
- "nix 0.28.0",
+ "nix 0.27.1",
  "rand 0.8.5",
 ]
 
@@ -780,9 +780,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 
 [[package]]
 name = "cfg-if"
@@ -791,16 +791,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -848,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -1025,16 +1019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
- "serde",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1028,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1112,6 +1102,15 @@ dependencies = [
  "serde_json",
  "tempdir",
  "tokio",
+]
+
+[[package]]
+name = "e2e-test-forwarder"
+version = "0.1.0"
+dependencies = [
+ "edgehog-device-runtime-forwarder",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1845,11 +1844,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2206,6 +2205,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2248,33 +2256,34 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
  "bit-set",
+ "diff",
  "ena",
- "itertools 0.11.0",
+ "is-terminal",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.7.5",
  "string_cache",
  "term",
  "tiny-keccak",
  "unicode-xid",
- "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
- "regex-automata",
+ "regex",
 ]
 
 [[package]]
@@ -2538,13 +2547,12 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -2583,12 +2591,6 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2924,12 +2926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,11 +2939,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
+ "itertools 0.10.5",
  "predicates-core",
 ]
 
@@ -3216,7 +3213,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3227,8 +3224,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -3247,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.25"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3276,7 +3279,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration 0.6.0",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
@@ -3320,7 +3323,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -3584,15 +3587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3724,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -4179,18 +4173,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
-dependencies = [
- "bitflags 2.4.2",
- "core-foundation",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -4198,16 +4181,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4295,14 +4268,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
- "deranged",
  "itoa",
- "num-conv",
- "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4310,17 +4280,16 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
- "num-conv",
  "time-core",
 ]
 
@@ -4495,21 +4464,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
@@ -4522,20 +4491,20 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow 0.5.40",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow",
 ]
 
 [[package]]
@@ -4784,9 +4753,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec26a25bd6fca441cdd0f769fd7f891bae119f996de31f86a5eddccef54c1d"
+checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
 
 [[package]]
 name = "vcpkg"
@@ -4805,16 +4774,6 @@ name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -4956,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
  "redox_syscall",
  "wasite",
@@ -4989,15 +4948,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -5151,15 +5101,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
 name = "e2e-test-forwarder"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "edgehog-device-runtime-forwarder",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -62,6 +62,21 @@ dependencies = [
 
 [[package]]
 name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon 1.0.2",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
@@ -69,7 +84,7 @@ dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon",
+ "anstyle-wincon 3.0.2",
  "colorchoice",
  "utf8parse",
 ]
@@ -100,6 +115,16 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
@@ -110,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ascii-canvas"
@@ -155,7 +180,7 @@ dependencies = [
  "once_cell",
  "p384",
  "rand_core 0.6.4",
- "reqwest 0.11.27",
+ "reqwest 0.11.25",
  "rumqttc",
  "rustls 0.20.9",
  "rustls-native-certs 0.6.3",
@@ -179,7 +204,7 @@ checksum = "198f6d26ba88696ef4d6c3b3940ca2cd27f1c08b8c7e1547e805d7fb4fcc7389"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -250,7 +275,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.3.0",
+ "futures-lite 2.2.0",
  "slab",
 ]
 
@@ -265,7 +290,7 @@ dependencies = [
  "async-io 2.3.2",
  "async-lock 3.3.0",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite 2.2.0",
  "once_cell",
 ]
 
@@ -299,10 +324,10 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.2.0",
  "parking",
  "polling 3.5.0",
- "rustix 0.38.32",
+ "rustix 0.38.31",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -350,19 +375,19 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.32",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-recursion"
-version = "1.1.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -377,7 +402,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.31",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -430,7 +455,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -441,13 +466,13 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -619,9 +644,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -658,7 +683,7 @@ dependencies = [
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.2.0",
  "piper",
  "tracing",
 ]
@@ -788,21 +813,22 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
 dependencies = [
  "clap_builder",
  "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
 dependencies = [
- "anstream",
+ "anstream 0.3.2",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -810,21 +836,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -995,7 +1021,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1059,7 +1085,7 @@ source = "git+https://github.com/joshuachp/displaydoc#ccedb07dc07c23387b8f833bd2
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1172,6 +1198,7 @@ name = "edgehog-device-runtime-forwarder"
 version = "0.1.0"
 dependencies = [
  "astarte-device-sdk",
+ "async-trait",
  "backoff",
  "displaydoc",
  "edgehog-device-forwarder-proto",
@@ -1257,7 +1284,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1276,7 +1303,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
 dependencies = [
- "anstream",
+ "anstream 0.6.13",
  "anstyle",
  "env_filter",
  "humantime",
@@ -1479,7 +1506,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1597,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
@@ -1616,7 +1643,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1704,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1937,14 +1964,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.24",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -2158,6 +2185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,7 +2318,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall",
 ]
@@ -2444,7 +2482,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2482,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "new_debug_unreachable"
-version = "1.0.6"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
@@ -2504,7 +2542,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2613,7 +2651,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2630,7 +2668,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2802,7 +2840,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2880,7 +2918,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix 0.38.31",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2936,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2960,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2973,13 +3011,13 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "chrono",
  "flate2",
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix 0.38.32",
+ "rustix 0.38.31",
 ]
 
 [[package]]
@@ -2988,7 +3026,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "chrono",
  "hex",
 ]
@@ -3020,7 +3058,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.53",
+ "syn 2.0.52",
  "tempfile",
  "which",
 ]
@@ -3035,7 +3073,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3209,16 +3247,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.11.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.24",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3238,7 +3276,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
+ "system-configuration 0.6.0",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
@@ -3282,7 +3320,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -3413,11 +3451,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys 0.4.13",
@@ -3648,7 +3686,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3681,7 +3719,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3707,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.7.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -3792,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -3952,7 +3990,7 @@ checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "byteorder",
  "bytes",
  "crc",
@@ -3994,7 +4032,7 @@ checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.4.2",
  "byteorder",
  "crc",
  "dotenvy",
@@ -4103,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4141,7 +4179,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+dependencies = [
+ "bitflags 2.4.2",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -4149,6 +4198,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4193,7 +4252,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "rustix 0.38.32",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -4231,7 +4290,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4307,7 +4366,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4348,7 +4407,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4436,14 +4495,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.6",
 ]
 
 [[package]]
@@ -4468,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
@@ -4490,7 +4549,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2 0.3.25",
+ "h2 0.3.24",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -4558,7 +4617,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4714,9 +4773,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
  "serde",
@@ -4725,9 +4784,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
+checksum = "8fec26a25bd6fca441cdd0f769fd7f891bae119f996de31f86a5eddccef54c1d"
 
 [[package]]
 name = "vcpkg"
@@ -4799,7 +4858,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -4833,7 +4892,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4892,7 +4951,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.32",
+ "rustix 0.38.31",
 ]
 
 [[package]]
@@ -5226,7 +5285,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5246,7 +5305,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ rust-version = { workspace = true }
 [workspace]
 resolver = "2"
 members = [
-      "e2e-test", "e2e-test-forwarder",
-      "edgehog-device-runtime-docker",
-      "edgehog-device-runtime-forwarder",
-      "hardware-id-service",
-      "led-manager-service",
+  "e2e-test",
+  "e2e-test-forwarder",
+  "edgehog-device-runtime-docker",
+  "edgehog-device-runtime-forwarder",
+  "hardware-id-service",
+  "led-manager-service",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ rust-version = { workspace = true }
 [workspace]
 resolver = "2"
 members = [
-  "e2e-test",
-  "edgehog-device-runtime-docker",
-  "edgehog-device-runtime-forwarder",
-  "hardware-id-service",
-  "led-manager-service",
+      "e2e-test", "e2e-test-forwarder",
+      "edgehog-device-runtime-docker",
+      "edgehog-device-runtime-forwarder",
+      "hardware-id-service",
+      "led-manager-service",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ rust-version = { workspace = true }
 [workspace]
 resolver = "2"
 members = [
-    "e2e-test",
-    "edgehog-device-runtime-docker",
-    "edgehog-device-runtime-forwarder",
-    "hardware-id-service",
-    "led-manager-service",
+  "e2e-test",
+  "edgehog-device-runtime-docker",
+  "edgehog-device-runtime-forwarder",
+  "hardware-id-service",
+  "led-manager-service",
 ]
 
 [workspace.package]
@@ -97,7 +97,7 @@ reqwest = "0.12.0"
 rustc_version_runtime = "0.3.0"
 rustls = "0.22.2"
 rustls-native-certs = "0.7.0"
-rustls-pemfile = "2.1.0"
+rustls-pemfile = "2.1.1"
 serde = "1.0.195"
 serde_json = "1.0.111"
 sysinfo = "0.29.11"

--- a/e2e-test-forwarder/Cargo.toml
+++ b/e2e-test-forwarder/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 edgehog-forwarder = { workspace = true, features = ["_test-utils"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/e2e-test-forwarder/Cargo.toml
+++ b/e2e-test-forwarder/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 # SPDX-License-Identifier: Apache-2.0
 
 [package]

--- a/e2e-test-forwarder/Cargo.toml
+++ b/e2e-test-forwarder/Cargo.toml
@@ -1,0 +1,16 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "e2e-test-forwarder"
+version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+edgehog-forwarder = { workspace = true, features = ["_test-utils"] }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/e2e-test-forwarder/Cargo.toml
+++ b/e2e-test-forwarder/Cargo.toml
@@ -6,6 +6,7 @@ name = "e2e-test-forwarder"
 version = "0.1.0"
 edition.workspace = true
 homepage.workspace = true
+publish = false
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -13,5 +14,6 @@ rust-version.workspace = true
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 edgehog-forwarder = { workspace = true, features = ["_test-utils"] }
+env_logger = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["log"] }

--- a/e2e-test-forwarder/src/main.rs
+++ b/e2e-test-forwarder/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use edgehog_forwarder::test_utils::con_manager;
 use tokio::task::JoinSet;
 use tracing::info;
 
@@ -23,7 +24,8 @@ struct Cli {
 
 #[tokio::main]
 async fn main() {
-    use edgehog_forwarder::test_utils::con_manager;
+    env_logger::init();
+
     let Cli {
         host,
         port,

--- a/e2e-test-forwarder/src/main.rs
+++ b/e2e-test-forwarder/src/main.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 SECO Mind Srl
+// SPDX-License-Identifier: Apache-2.0
+
+use tokio::task::JoinSet;
+use tracing::info;
+
+#[tokio::main]
+async fn main() {
+    use edgehog_forwarder::test_utils::con_manager;
+
+    let mut js = JoinSet::new();
+
+    js.spawn(con_manager(
+        "ws://localhost:4000/device/websocket?session=abcd".to_string(),
+        false,
+    ));
+
+    while let Some(res) = js.join_next().await {
+        info!("{res:?}");
+    }
+}

--- a/e2e-test-forwarder/src/main.rs
+++ b/e2e-test-forwarder/src/main.rs
@@ -11,7 +11,7 @@ async fn main() {
     let mut js = JoinSet::new();
 
     js.spawn(con_manager(
-        "ws://localhost:4000/device/websocket?session=abcd".to_string(),
+        "ws://kaiki.local:4000/device/websocket?session=abcd".to_string(),
         false,
     ));
 

--- a/e2e-test-forwarder/src/main.rs
+++ b/e2e-test-forwarder/src/main.rs
@@ -1,19 +1,37 @@
 // Copyright 2023 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use tokio::task::JoinSet;
 use tracing::info;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    /// Host address of the forwarder server
+    #[arg(long, short = 'H')]
+    host: String,
+    /// Port of the forwarder server
+    #[arg(short, long, default_value_t = 4000)]
+    port: u16,
+    /// Session token
+    #[arg(short, long)]
+    token: String,
+}
 
 #[tokio::main]
 async fn main() {
     use edgehog_forwarder::test_utils::con_manager;
+    let Cli { host, port, token } = Cli::parse();
 
+    let url = format!("ws://{host}:{port}/device/websocket?session={token}");
     let mut js = JoinSet::new();
 
     js.spawn(con_manager(
         "ws://kaiki.local:4000/device/websocket?session=abcd".to_string(),
         false,
     ));
+    let secure = false;
+    js.spawn(con_manager(url, secure));
 
     while let Some(res) = js.join_next().await {
         info!("{res:?}");

--- a/e2e-test-forwarder/src/main.rs
+++ b/e2e-test-forwarder/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 SECO Mind Srl
+// Copyright 2023-2024 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;

--- a/edgehog-device-runtime-forwarder/Cargo.toml
+++ b/edgehog-device-runtime-forwarder/Cargo.toml
@@ -1,19 +1,4 @@
-# This file is part of Edgehog.
-#
 # Copyright 2023 SECO Mind Srl
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
@@ -52,4 +37,4 @@ tokio = { workspace = true, features = ["test-util"] }
 uuid = { workspace = true }
 
 [features]
-_test-utils = ["dep:httpmock", "dep:uuid", "tokio/test-util"]
+_test-utils = ["dep:httpmock", "tokio/test-util"]

--- a/edgehog-device-runtime-forwarder/Cargo.toml
+++ b/edgehog-device-runtime-forwarder/Cargo.toml
@@ -26,14 +26,15 @@ rust-version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { workspace = true }
 astarte-device-sdk = { workspace = true, features = ["derive"] }
+async-trait = { workspace = true }
 backoff = { workspace = true, features = ["tokio"] }
 displaydoc = { workspace = true }
 edgehog-device-forwarder-proto = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+httpmock = { workspace = true, optional = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
@@ -43,8 +44,12 @@ tokio = { workspace = true }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 tracing = { workspace = true, features = ["log"] }
 url = { workspace = true }
+uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 uuid = { workspace = true }
+
+[features]
+_test-utils = ["dep:httpmock", "dep:uuid", "tokio/test-util"]

--- a/edgehog-device-runtime-forwarder/Cargo.toml
+++ b/edgehog-device-runtime-forwarder/Cargo.toml
@@ -26,6 +26,7 @@ rust-version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { workspace = true }
 astarte-device-sdk = { workspace = true, features = ["derive"] }
 backoff = { workspace = true, features = ["tokio"] }
 displaydoc = { workspace = true }

--- a/edgehog-device-runtime-forwarder/Cargo.toml
+++ b/edgehog-device-runtime-forwarder/Cargo.toml
@@ -29,12 +29,10 @@ tokio = { workspace = true }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 tracing = { workspace = true, features = ["log"] }
 url = { workspace = true }
-uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
-uuid = { workspace = true }
 
 [features]
 _test-utils = ["dep:httpmock", "tokio/test-util"]

--- a/edgehog-device-runtime-forwarder/README.md
+++ b/edgehog-device-runtime-forwarder/README.md
@@ -8,8 +8,10 @@
 ## Overview
 
 The Edgehog Device Runtime Forwarder Library facilitates the communication and interaction
-between devices and Edgehog through WebSocket connections. This README provides a guide to
-understanding the structure of the library and how its components work together.
+between devices and Edgehog through WebSocket connections. This could be useful in the scenario where a remote user, who
+has access to an Edgehog bridge, wishes to open a remote terminal exposed by the device on a specific port and make it
+accessible through a WebSocket connection.
+This README provides a guide to  understanding the structure of the library and how its components work together.
 
 ## Sequence Diagram
 
@@ -51,9 +53,9 @@ to Edgehog.
 
 - Establishes a WebSocket connection between the device and Edgehog.
 - Acts as a multiplexer for forwarding messages between Edgehog and internal device connections (e.g., with
-  [ttyd](https://github.com/tsl0922/ttyd)).
-- Handles WebSocket frames (carrying HTTP requests/responses), decoding binary data into an internal Rust
-  representation.
+[ttyd](https://github.com/tsl0922/ttyd)).
+- Handles WebSocket frames (carrying HTTP requests/responses or other WebSocket frames), decoding binary data into an
+  internal Rust representation.
 - Handles reconnection operations on WebSocket errors.
 - Maintains a collection of connections with channel writing handles.
 
@@ -65,10 +67,10 @@ to Edgehog.
 
 ### Connection
 
-- Defines `Connection` and `ConnectionHandle` structs.
-- Creates a new connection.
+- Defines `Connection` and `ConnectionHandle` structs, necessary to create new connections. At the moment, the only
+supported connections types are HTTP and WebSocket.
 - Spawns Tokio tasks responsible for managing connections.
-- Sends HTTP requests (e.g., to ttyd) and encodes responses into protobuf messages.
+- Sends messages and encodes responses into protobuf messages.
 
 ### Messages
 

--- a/edgehog-device-runtime-forwarder/src/astarte.rs
+++ b/edgehog-device-runtime-forwarder/src/astarte.rs
@@ -76,7 +76,7 @@ mod tests {
             host: Ipv4Addr::LOCALHOST.to_string(),
             port: 8080,
             session_token: session_token.to_string(),
-            secure: false
+            secure: false,
         }
     }
 

--- a/edgehog-device-runtime-forwarder/src/astarte.rs
+++ b/edgehog-device-runtime-forwarder/src/astarte.rs
@@ -71,12 +71,12 @@ mod tests {
     use std::net::Ipv4Addr;
     use url::Host;
 
-    fn create_sinfo(token: &str) -> SessionInfo {
+    fn create_sinfo(session_token: &str) -> SessionInfo {
         SessionInfo {
             host: Ipv4Addr::LOCALHOST.to_string(),
             port: 8080,
-            session_token: token.to_string(),
-            secure: false,
+            session_token: session_token.to_string(),
+            secure: false
         }
     }
 

--- a/edgehog-device-runtime-forwarder/src/collection.rs
+++ b/edgehog-device-runtime-forwarder/src/collection.rs
@@ -58,7 +58,7 @@ impl Connections {
         })?;
 
         // before executing the HTTP request, check if it is an Upgrade request.
-        if http_req.is_upgrade() {
+        if http_req.is_ws_upgrade() {
             info!("Connection upgrade");
             return self.add_ws(request_id, http_req);
         }
@@ -73,7 +73,7 @@ impl Connections {
     /// Create a new WebSocket [`Connection`].
     #[instrument(skip(self))]
     fn add_ws(&mut self, request_id: Id, http_req: HttpRequest) -> Result<(), Error> {
-        debug_assert!(http_req.is_upgrade());
+        debug_assert!(http_req.is_ws_upgrade());
 
         let tx_ws = self.tx_ws.clone();
 

--- a/edgehog-device-runtime-forwarder/src/collection.rs
+++ b/edgehog-device-runtime-forwarder/src/collection.rs
@@ -119,7 +119,7 @@ impl Connections {
 
                 let handle = entry.get_mut();
 
-                // check if the the connection is finished or not. If it is finished, return the
+                // check if the connection is finished or not. If it is finished, return the
                 // entry so that a new connection with the same Key can be created
                 if !handle.is_finished() {
                     return Err(Error::IdAlreadyUsed(id));

--- a/edgehog-device-runtime-forwarder/src/connection.rs
+++ b/edgehog-device-runtime-forwarder/src/connection.rs
@@ -210,7 +210,7 @@ impl WebSocketBuilder {
     /// Upgrade the HTTP request and build the channel used to send WebSocket messages to device
     /// services (e.g., TTYD).
     fn with_handle(http_req: ProtoHttpRequest) -> Result<(Self, WriteHandle), ConnectionError> {
-        let request = http_req.upgrade()?;
+        let request = http_req.ws_upgrade()?;
         trace!("HTTP request upgraded");
 
         // this channel that will be used to send data from the manager to the websocket connection
@@ -544,12 +544,12 @@ mod tests {
 
         let id = Id::try_from(b"1234".to_vec()).unwrap();
 
-        let res = http.next(&id).await;
+        let res = http.next(&id).await.unwrap().unwrap();
 
         // check that there has been an HTTP call with the specified information
         mock_http_req.assert();
 
-        let proto_msg = res.unwrap().unwrap().into_http().unwrap();
+        let proto_msg = res.into_http().unwrap();
         assert_eq!(proto_msg.request_id, id);
 
         let res = proto_msg.http_msg.into_res().unwrap();

--- a/edgehog-device-runtime-forwarder/src/connection.rs
+++ b/edgehog-device-runtime-forwarder/src/connection.rs
@@ -6,30 +6,51 @@
 //! A connection is responsible for sending and receiving data through a WebSocket connection from
 //! and to the [`ConnectionsManager`](crate::connections_manager::ConnectionsManager).
 
-use std::ops::{Deref, DerefMut};
+use std::ops::{ControlFlow, Deref, DerefMut};
 
+use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
+use http::Request;
 use thiserror::Error as ThisError;
-use tokio::sync::mpsc::Sender;
+use tokio::select;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::task::{JoinError, JoinHandle};
-use tracing::{debug, error, instrument};
+use tokio_tungstenite::tungstenite::{Error as TungError, Message as TungMessage};
+use tracing::{debug, error, instrument, trace};
 
+use crate::connections_manager::WsStream;
 use crate::messages::{
-    Http as ProtoHttp, HttpMessage as ProtoHttpMessage, HttpResponse, Id, ProtoMessage,
-    ProtocolError,
+    Http as ProtoHttp, HttpMessage as ProtoHttpMessage, HttpRequest as ProtoHttpRequest,
+    HttpResponse as ProtoHttpResponse, Id, ProtoMessage, ProtocolError,
+    WebSocketMessage as ProtoWebSocketMessage,
 };
+
+pub(crate) const WS_CHANNEL_SIZE: usize = 50;
 
 /// Connection errors.
 #[non_exhaustive]
 #[derive(displaydoc::Display, ThisError, Debug)]
 pub enum ConnectionError {
     /// Channel error.
-    ChannelToWs,
+    Channel(&'static str),
     /// Reqwest error.
-    Reqwest(#[from] reqwest::Error),
+    Http(#[from] reqwest::Error),
     /// Protobuf error.
     Protobuf(#[from] ProtocolError),
     /// Failed to Join a task handle.
     JoinError(#[from] JoinError),
+    /// Message sent to the wrong protocol
+    WrongProtocol,
+    /// Error when receiving message on websocket connection, `{0}`.
+    WebSocket(#[from] TungError),
+    /// Trying to poll while still connecting.
+    Connecting,
+}
+
+#[derive(Debug)]
+pub(crate) enum WriteHandle {
+    Http,
+    Ws(Sender<ProtoWebSocketMessage>),
 }
 
 /// Handle to the task spawned to handle a [`Connection`].
@@ -37,6 +58,29 @@ pub enum ConnectionError {
 pub(crate) struct ConnectionHandle {
     /// Handle of the task managing the connection.
     pub(crate) handle: JoinHandle<()>,
+    /// Handle used to send messages to the tokio task of a certain connection.
+    pub(crate) connection: WriteHandle,
+}
+
+impl ConnectionHandle {
+    /// Once the connections manager receives a WebSocket message, it sends a message to the
+    /// respective tokio task handling that connection.
+    #[instrument]
+    pub(crate) async fn send(&self, msg: ProtoMessage) -> Result<(), ConnectionError> {
+        match &self.connection {
+            WriteHandle::Http => Err(ConnectionError::Channel(
+                "sending messages over a channel is only allowed for WebSocket connections",
+            )),
+            WriteHandle::Ws(tx_con) => {
+                let message = msg.into_ws().ok_or(ConnectionError::WrongProtocol)?.message;
+                tx_con.send(message).await.map_err(|_| {
+                    ConnectionError::Channel(
+                        "error while sending messages to the ConnectionsManager",
+                    )
+                })
+            }
+        }
+    }
 }
 
 impl Deref for ConnectionHandle {
@@ -53,63 +97,471 @@ impl DerefMut for ConnectionHandle {
     }
 }
 
-/// Struct containing a connection information useful to communicate with the
-/// [`ConnectionsManager`](crate::collection::ConnectionsManager).
+/// Trait used by each transport builder (e.g., [`HttpBuilder`], [`WebSocketBuilder`]) to build the
+/// respective transport protocol struct.
+#[async_trait]
+pub(crate) trait TransportBuilder {
+    type Connection: Transport;
+
+    async fn build(
+        self,
+        id: &Id,
+        tx_ws: Sender<ProtoMessage>,
+    ) -> Result<Self::Connection, ConnectionError>;
+}
+
+/// For each Connection implementing a given transport protocol (e.g., [`Http`], [`WebSocket`]), it
+/// provides a method returning a [`protocol message`](ProtoMessage) to send to the connections
+/// manager.
+#[async_trait]
+pub(crate) trait Transport {
+    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError>;
+}
+
+/// Builder for an [`Http`] connection.
 #[derive(Debug)]
-pub(crate) struct Connection {
-    id: Id,
-    tx_ws: Sender<ProtoMessage>,
+
+pub(crate) struct HttpBuilder {
+    /// To send the request the builder must be consumed, so the option can be replaced with None
     request: reqwest::RequestBuilder,
 }
 
-impl Connection {
-    /// Initialize a new connection.
-    pub(crate) fn new(
-        id: Id,
+impl HttpBuilder {
+    fn new(request: reqwest::RequestBuilder) -> Self {
+        Self { request }
+    }
+}
+
+#[async_trait]
+impl TransportBuilder for HttpBuilder {
+    type Connection = Http;
+
+    /// The id and the channel are only useful for [`WebSocket`] connections.
+    async fn build(
+        self,
+        _id: &Id,
+        _tx_ws: Sender<ProtoMessage>,
+    ) -> Result<Self::Connection, ConnectionError> {
+        Ok(Http::new(self.request))
+    }
+}
+
+impl TryFrom<ProtoHttpRequest> for HttpBuilder {
+    type Error = ConnectionError;
+
+    fn try_from(value: ProtoHttpRequest) -> Result<Self, Self::Error> {
+        value
+            .request_builder()
+            .map(HttpBuilder::new)
+            .map_err(ConnectionError::from)
+    }
+}
+
+/// HTTP connection protocol
+#[derive(Debug)]
+pub(crate) struct Http {
+    /// To send the request the builder must be consumed, so the option can be replaced with None.
+    request: Option<reqwest::RequestBuilder>,
+}
+
+impl Http {
+    /// Store the HTTP request the connection will respond to once executed.
+    pub(crate) fn new(request: reqwest::RequestBuilder) -> Self {
+        Self {
+            request: Some(request),
+        }
+    }
+}
+
+#[async_trait]
+impl Transport for Http {
+    /// Send the [HTTP request](reqwest::Request), wait for a response and return it.
+    #[instrument(skip(self))]
+    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
+        let Some(request) = self.request.take() else {
+            return Ok(None);
+        };
+
+        trace!("sending HTTP request");
+        let http_res = request.send().await?;
+
+        // create the protobuf response to send to the bridge
+        let proto_res = ProtoHttpResponse::from_reqw_response(http_res).await?;
+
+        debug!("response code {}", proto_res.status());
+
+        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
+            id.clone(),
+            ProtoHttpMessage::Response(proto_res),
+        ));
+
+        Ok(Some(proto_msg))
+    }
+}
+
+/// Builder for an [`WebSocket`] connection.
+#[derive(Debug)]
+pub(crate) struct WebSocketBuilder {
+    request: Request<()>,
+    rx_con: Receiver<ProtoWebSocketMessage>,
+}
+
+impl WebSocketBuilder {
+    /// Upgrade the HTTP request and build the channel used to send WebSocket messages to device
+    /// services (e.g., TTYD).
+    fn with_handle(http_req: ProtoHttpRequest) -> Result<(Self, WriteHandle), ConnectionError> {
+        let request = http_req.upgrade()?;
+        trace!("HTTP request upgraded");
+
+        // this channel that will be used to send data from the manager to the websocket connection
+        let (tx_con, rx_con) = channel::<ProtoWebSocketMessage>(WS_CHANNEL_SIZE);
+
+        Ok((Self { request, rx_con }, WriteHandle::Ws(tx_con)))
+    }
+}
+
+#[async_trait]
+impl TransportBuilder for WebSocketBuilder {
+    type Connection = WebSocket;
+
+    #[instrument(skip(self, tx_ws))]
+    async fn build(
+        self,
+        id: &Id,
         tx_ws: Sender<ProtoMessage>,
-        request: reqwest::RequestBuilder,
-    ) -> Self {
-        Self { id, tx_ws, request }
+    ) -> Result<Self::Connection, ConnectionError> {
+        // establish a WebSocket connection
+        let (ws_stream, http_res) = tokio_tungstenite::connect_async(self.request).await?;
+        trace!("WebSocket stream for ID {id} created");
+
+        // send a ProtoMessage with the HTTP generated response to the connections manager
+        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
+            id.clone(),
+            ProtoHttpMessage::Response(ProtoHttpResponse::try_from(http_res)?),
+        ));
+
+        tx_ws.send(proto_msg).await.map_err(|_| {
+            ConnectionError::Channel(
+                "error while returning the Http upgrade response to the ConnectionsManager",
+            )
+        })?;
+
+        Ok(WebSocket::new(ws_stream, self.rx_con))
+    }
+}
+
+/// WebSocket connection protocol.
+#[derive(Debug)]
+pub(crate) struct WebSocket {
+    ws_stream: WsStream,
+    rx_con: Receiver<ProtoWebSocketMessage>,
+}
+
+#[async_trait]
+impl Transport for WebSocket {
+    /// Write/Read to/from a WebSocket.
+    ///
+    /// Returns a result only when the device receives a message from a WebSocket connection.
+    /// If a message needs to be forwarded to the device's WebSocket connection, a recursive
+    /// function call will be invoked.
+    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
+        match self.select().await {
+            // message from internal websocket connection (e.g., with TTYD) to the connections manager
+            WsEither::Read(tung_res) => self.handle_ws_read(id.clone(), tung_res).await,
+            // message from the connections manager to the internal websocket connection
+            WsEither::Write(chan_data) => {
+                if let ControlFlow::Break(()) = self.handle_ws_write(chan_data).await? {
+                    return Ok(None);
+                }
+                self.next(id).await
+            }
+        }
+    }
+}
+
+impl WebSocket {
+    fn new(ws_stream: WsStream, rx_con: Receiver<ProtoWebSocketMessage>) -> Self {
+        Self { ws_stream, rx_con }
+    }
+
+    /// The device can either receive a message from the WebSocket connection or may need to
+    /// forward data to it.
+    async fn select(&mut self) -> WsEither {
+        select! {
+            tung_res = self.ws_stream.next() => WsEither::Read(tung_res),
+            chan_data = self.rx_con.recv() => WsEither::Write(chan_data)
+        }
+    }
+
+    /// Handle the reception of new data from a WebSocket connection.
+    #[instrument(skip(self, tung_res))]
+    async fn handle_ws_read(
+        &mut self,
+        id: Id,
+        tung_res: Option<Result<TungMessage, TungError>>,
+    ) -> Result<Option<ProtoMessage>, ConnectionError> {
+        match tung_res {
+            // ws stream closed
+            None => {
+                debug!("ws stream {id} has been closed, exit");
+                Ok(None)
+            }
+            Some(Ok(tung_msg)) => Ok(Some(ProtoMessage::try_from_tung(id, tung_msg)?)),
+            Some(Err(err)) => Err(err.into()),
+        }
+    }
+
+    /// Forward data from the [`ConnectionsManager`](crate::connections_manager::ConnectionsManager)
+    /// to the device WebSocket connection.
+    #[instrument(skip_all)]
+    async fn handle_ws_write(
+        &mut self,
+        chan_data: Option<ProtoWebSocketMessage>,
+    ) -> Result<ControlFlow<()>, ConnectionError> {
+        // convert the websocket proto message into a Tung message
+        match chan_data {
+            None => {
+                debug!("channel dropped, closing connection");
+                Ok(ControlFlow::Break(()))
+            }
+            Some(ws_msg) => {
+                self.ws_stream.send(ws_msg.into()).await?;
+                trace!("message sent to TTYD");
+                Ok(ControlFlow::Continue(()))
+            }
+        }
+    }
+}
+
+/// Utility enum to avoid having too much code in the [`select`] macro branches.
+enum WsEither {
+    Read(Option<Result<TungMessage, TungError>>),
+    Write(Option<ProtoWebSocketMessage>),
+}
+
+/// Struct containing a connection information useful to communicate with the
+/// [`ConnectionsManager`](crate::collection::ConnectionsManager).
+#[derive(Debug)]
+pub(crate) struct Connection<T> {
+    id: Id,
+    tx_ws: Sender<ProtoMessage>,
+    state: T,
+}
+
+impl<T> Connection<T> {
+    /// Initialize a new connection.
+    pub(crate) fn new(id: Id, tx_ws: Sender<ProtoMessage>, state: T) -> Self {
+        Self { id, tx_ws, state }
     }
 
     /// Spawn the task responsible for handling the connection.
     #[instrument(skip_all)]
-    pub(crate) fn spawn(self) -> ConnectionHandle {
+    pub(crate) fn spawn(self, write_handle: WriteHandle) -> ConnectionHandle
+    where
+        T: TransportBuilder + Send + 'static,
+        <T as TransportBuilder>::Connection: Send,
+    {
         // spawn a task responsible for notifying when new data is available
         let handle = tokio::spawn(async move { self.spawn_inner().await });
 
-        ConnectionHandle { handle }
+        ConnectionHandle {
+            handle,
+            connection: write_handle,
+        }
     }
 
     #[instrument(skip_all, fields(id = %self.id))]
-    async fn spawn_inner(self) {
+    async fn spawn_inner(self)
+    where
+        T: TransportBuilder + Send + 'static,
+        <T as TransportBuilder>::Connection: Send,
+    {
         if let Err(err) = self.task().await {
             error!("connection task failed with error {err:?}");
         }
     }
 
     /// Send an HTTP request, wait for a response, build a protobuf message and send it to the
-    /// [`ConnectionsManager`](crate::collection::ConnectionsManager).
+    /// [ConnectionsManager](crate::connections_manager::ConnectionsManager).
     #[instrument(skip_all, fields(id = %self.id))]
-    async fn task(self) -> Result<(), ConnectionError> {
-        let http_res = self.request.send().await?;
+    pub(crate) async fn task(self) -> Result<(), ConnectionError>
+    where
+        T: TransportBuilder,
+    {
+        // create a connection (either HTTP or WebSocket) which implements the Transport trait
+        let mut connection = self.state.build(&self.id, self.tx_ws.clone()).await?;
+        trace!("connection {} created", self.id);
 
-        let status_code = http_res.status();
-        let headers = http_res.headers().clone();
-        let body = http_res.bytes().await?.into();
+        while let Some(proto_msg) = connection.next(&self.id).await? {
+            self.tx_ws.send(proto_msg).await.map_err(|_| {
+                ConnectionError::Channel(
+                    "error while sending generic message to the ConnectionsManager",
+                )
+            })?;
+        }
 
-        let proto_res = HttpResponse::new(status_code, headers, body);
+        Ok(())
+    }
+}
 
-        debug!("response code {}", proto_res.status());
+impl Connection<HttpBuilder> {
+    /// Initialize a new Http connection.
+    #[instrument(skip(tx_ws, http_req))]
+    pub(crate) fn with_http(
+        id: Id,
+        tx_ws: Sender<ProtoMessage>,
+        http_req: ProtoHttpRequest,
+    ) -> Result<ConnectionHandle, ConnectionError> {
+        let http_builder = HttpBuilder::try_from(http_req)?;
+        let con = Self::new(id, tx_ws, http_builder);
+        Ok(con.spawn(WriteHandle::Http))
+    }
+}
 
-        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
-            self.id,
-            ProtoHttpMessage::Response(proto_res),
-        ));
+impl Connection<WebSocketBuilder> {
+    /// Initialize a new WebSocket connection.
+    #[instrument(skip(tx_ws, http_req))]
+    pub(crate) fn with_ws(
+        id: Id,
+        tx_ws: Sender<ProtoMessage>,
+        http_req: ProtoHttpRequest,
+    ) -> Result<ConnectionHandle, ConnectionError> {
+        let (ws_builder, write_handle) = WebSocketBuilder::with_handle(http_req)?;
+        let con = Self::new(id, tx_ws, ws_builder);
+        Ok(con.spawn(write_handle))
+    }
+}
 
-        self.tx_ws
-            .send(proto_msg)
-            .await
-            .map_err(|_| ConnectionError::ChannelToWs)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messages::WebSocket as ProtoWebSocket;
+    use http::header::CONTENT_TYPE;
+    use http::HeaderValue;
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+    use url::Url;
+
+    async fn empty_task() {}
+
+    fn create_http_req_proto(url: Url) -> ProtoHttpRequest {
+        ProtoHttpRequest {
+            method: http::Method::GET,
+            path: url.path().trim_start_matches('/').to_string(),
+            query_string: url.query().unwrap_or_default().to_string(),
+            headers: http::HeaderMap::new(),
+            body: Vec::new(),
+            port: url.port().expect("nonexistent port"),
+        }
+    }
+
+    fn create_http_req_msg_proto(url: &str) -> ProtoMessage {
+        let url = Url::parse(url).expect("failed to pars Url");
+
+        ProtoMessage::Http(ProtoHttp::new(
+            Id::try_from(b"1234".to_vec()).unwrap(),
+            ProtoHttpMessage::Request(create_http_req_proto(url)),
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_con_handle_send() {
+        let (tx, mut rx) = channel::<ProtoWebSocketMessage>(WS_CHANNEL_SIZE);
+
+        let con_handle = ConnectionHandle {
+            handle: tokio::spawn(empty_task()),
+            connection: WriteHandle::Ws(tx),
+        };
+
+        let proto_msg = ProtoMessage::WebSocket(ProtoWebSocket {
+            socket_id: Id::try_from(b"1234".to_vec()).unwrap(),
+            message: ProtoWebSocketMessage::binary(b"message".to_vec()),
+        });
+
+        let res = con_handle.send(proto_msg).await;
+
+        assert!(res.is_ok());
+
+        let res = rx.recv().await.expect("channel error");
+        let expected_res = ProtoWebSocketMessage::binary(b"message".to_vec());
+
+        assert_eq!(res, expected_res);
+    }
+
+    #[tokio::test]
+    async fn test_con_handle_send_error() {
+        // send() cannot be used in case the write handle is Http
+        let con_handle = ConnectionHandle {
+            handle: tokio::spawn(empty_task()),
+            connection: WriteHandle::Http,
+        };
+
+        let proto_msg = ProtoMessage::WebSocket(ProtoWebSocket {
+            socket_id: Id::try_from(b"1234".to_vec()).unwrap(),
+            message: ProtoWebSocketMessage::binary(b"message".to_vec()),
+        });
+
+        let res = con_handle.send(proto_msg).await;
+
+        assert!(matches!(res, Err(ConnectionError::Channel(_))));
+
+        // an error is returned in case the proto message is not of websocket type
+        let (tx, _rx) = channel::<ProtoWebSocketMessage>(WS_CHANNEL_SIZE);
+        let con_handle = ConnectionHandle {
+            handle: tokio::spawn(empty_task()),
+            connection: WriteHandle::Ws(tx),
+        };
+
+        let proto_msg = create_http_req_msg_proto("https://host:8080/path?session_token=abcd");
+        let res = con_handle.send(proto_msg).await;
+
+        assert!(matches!(res, Err(ConnectionError::WrongProtocol)));
+    }
+
+    #[tokio::test]
+    async fn next_http() {
+        let mock_server = MockServer::start();
+
+        let mock_http_req = mock_server.mock(|when, then| {
+            when.method(GET)
+                .path("/path")
+                .query_param("session_token", "abcd");
+            then.status(200)
+                .header("content-type", "text/html")
+                .body("body");
+        });
+
+        let url = mock_server.url("/path?session_token=abcd");
+
+        let url = Url::parse(&url).expect("failed to parse Url");
+        let http_rep = create_http_req_proto(url);
+
+        let mut http = Http::new(
+            http_rep
+                .request_builder()
+                .expect("failed to retrieve request builder"),
+        );
+
+        let id = Id::try_from(b"1234".to_vec()).unwrap();
+
+        let res = http.next(&id).await;
+
+        // check that there has been an HTTP call with the specified information
+        mock_http_req.assert();
+
+        let proto_msg = res.unwrap().unwrap().into_http().unwrap();
+        assert_eq!(proto_msg.request_id, id);
+
+        let res = proto_msg.http_msg.into_res().unwrap();
+        assert_eq!(res.status_code, 200);
+        assert_eq!(res.body, b"body");
+        assert_eq!(
+            res.headers.get(CONTENT_TYPE).unwrap(),
+            HeaderValue::from_static("text/html")
+        );
+
+        // calling a second time next() on an http should return Ok(None)
+        let res = http.next(&id).await;
+        assert!(res.unwrap().is_none());
     }
 }

--- a/edgehog-device-runtime-forwarder/src/connection/http.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/http.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 SECO Mind Srl
+// Copyright 2024 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
 //! Define the necessary structs and traits to represent an HTTP connection.

--- a/edgehog-device-runtime-forwarder/src/connection/http.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/http.rs
@@ -18,7 +18,6 @@ use crate::messages::{
 /// Builder for an [`Http`] connection.
 #[derive(Debug)]
 pub(crate) struct HttpBuilder {
-    /// To send the request the builder must be consumed, so the option can be replaced with None
     request: reqwest::RequestBuilder,
 }
 
@@ -56,7 +55,7 @@ impl TryFrom<ProtoHttpRequest> for HttpBuilder {
 /// HTTP connection protocol
 #[derive(Debug)]
 pub(crate) struct Http {
-    /// To send the request the builder must be consumed, so the option can be replaced with None.
+    // to send the request the builder must be consumed, so the option can be replaced with None.
     request: Option<reqwest::RequestBuilder>,
 }
 
@@ -81,7 +80,7 @@ impl Transport for Http {
         trace!("sending HTTP request");
         match request.send().await {
             Ok(http_res) => {
-                // create the protobuf response to send to the bridge
+                // create the protobuf response to be sent to Edgehog
                 let proto_res = ProtoHttpResponse::from_reqw_response(http_res).await?;
 
                 let proto_msg = ProtoMessage::Http(ProtoHttp::new(

--- a/edgehog-device-runtime-forwarder/src/connection/http.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/http.rs
@@ -1,0 +1,95 @@
+// Copyright 2023 SECO Mind Srl
+// SPDX-License-Identifier: Apache-2.0
+
+//! Define the necessary structs and traits to represent an HTTP connection.
+
+use async_trait::async_trait;
+use tokio::sync::mpsc::Sender;
+use tracing::{debug, instrument, trace};
+
+use super::{ConnectionError, Transport, TransportBuilder};
+use crate::messages::{
+    Http as ProtoHttp, HttpMessage as ProtoHttpMessage, HttpRequest as ProtoHttpRequest,
+    HttpResponse as ProtoHttpResponse, Id, ProtoMessage,
+};
+
+/// Builder for an [`Http`] connection.
+#[derive(Debug)]
+
+pub(crate) struct HttpBuilder {
+    /// To send the request the builder must be consumed, so the option can be replaced with None
+    request: reqwest::RequestBuilder,
+}
+
+impl HttpBuilder {
+    fn new(request: reqwest::RequestBuilder) -> Self {
+        Self { request }
+    }
+}
+
+#[async_trait]
+impl TransportBuilder for HttpBuilder {
+    type Connection = Http;
+
+    /// The id and the channel are only useful for [`WebSocket`] connections.
+    async fn build(
+        self,
+        _id: &Id,
+        _tx_ws: Sender<ProtoMessage>,
+    ) -> Result<Self::Connection, ConnectionError> {
+        Ok(Http::new(self.request))
+    }
+}
+
+impl TryFrom<ProtoHttpRequest> for HttpBuilder {
+    type Error = ConnectionError;
+
+    fn try_from(value: ProtoHttpRequest) -> Result<Self, Self::Error> {
+        value
+            .request_builder()
+            .map(HttpBuilder::new)
+            .map_err(ConnectionError::from)
+    }
+}
+
+/// HTTP connection protocol
+#[derive(Debug)]
+pub(crate) struct Http {
+    /// To send the request the builder must be consumed, so the option can be replaced with None.
+    request: Option<reqwest::RequestBuilder>,
+}
+
+impl Http {
+    /// Store the HTTP request the connection will respond to once executed.
+    pub(crate) fn new(request: reqwest::RequestBuilder) -> Self {
+        Self {
+            request: Some(request),
+        }
+    }
+}
+
+#[async_trait]
+impl Transport for Http {
+    /// Send the [HTTP request](reqwest::Request), wait for a response and return it.
+    #[instrument(skip(self))]
+    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
+        let Some(request) = self.request.take() else {
+            return Ok(None);
+        };
+
+        trace!("sending HTTP request");
+        let http_res = request.send().await?;
+
+        // create the protobuf response to send to the bridge
+        let proto_res = ProtoHttpResponse::from_reqw_response(http_res).await?;
+
+        debug!("response code {}", proto_res.status());
+
+        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
+            id.clone(),
+            ProtoHttpMessage::Response(proto_res),
+        ));
+
+        Ok(Some(proto_msg))
+    }
+}

--- a/edgehog-device-runtime-forwarder/src/connection/http.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/http.rs
@@ -78,18 +78,23 @@ impl Transport for Http {
         };
 
         trace!("sending HTTP request");
-        let http_res = request.send().await?;
+        match request.send().await {
+            Ok(http_res) => {
+                // create the protobuf response to send to the bridge
+                let proto_res = ProtoHttpResponse::from_reqw_response(http_res).await?;
 
-        // create the protobuf response to send to the bridge
-        let proto_res = ProtoHttpResponse::from_reqw_response(http_res).await?;
+                let proto_msg = ProtoMessage::Http(ProtoHttp::new(
+                    id.clone(),
+                    ProtoHttpMessage::Response(proto_res),
+                ));
 
-        debug!("response code {}", proto_res.status());
-
-        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
-            id.clone(),
-            ProtoHttpMessage::Response(proto_res),
-        ));
-
-        Ok(Some(proto_msg))
+                Ok(Some(proto_msg))
+            }
+            Err(err) => {
+                debug!("HTTP request failed: {err}");
+                let proto_msg = ProtoMessage::Http(ProtoHttp::bad_gateway(id.clone()));
+                Ok(Some(proto_msg))
+            }
+        }
     }
 }

--- a/edgehog-device-runtime-forwarder/src/connection/mod.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/mod.rs
@@ -18,12 +18,7 @@ use tokio::task::{JoinError, JoinHandle};
 use tokio_tungstenite::tungstenite::Error as TungError;
 use tracing::{error, instrument, trace};
 
-use self::http::HttpBuilder;
-use self::websocket::WebSocketBuilder;
-use crate::messages::{
-    HttpRequest as ProtoHttpRequest, Id, ProtoMessage, ProtocolError,
-    WebSocketMessage as ProtoWebSocketMessage,
-};
+use crate::messages::{Id, ProtoMessage, ProtocolError, WebSocketMessage as ProtoWebSocketMessage};
 
 pub(crate) const WS_CHANNEL_SIZE: usize = 50;
 
@@ -180,42 +175,17 @@ impl<T> Connection<T> {
     }
 }
 
-impl Connection<HttpBuilder> {
-    /// Initialize a new Http connection.
-    #[instrument(skip(tx_ws, http_req))]
-    pub(crate) fn with_http(
-        id: Id,
-        tx_ws: Sender<ProtoMessage>,
-        http_req: ProtoHttpRequest,
-    ) -> Result<ConnectionHandle, ConnectionError> {
-        let http_builder = HttpBuilder::try_from(http_req)?;
-        let con = Self::new(id, tx_ws, http_builder);
-        Ok(con.spawn(WriteHandle::Http))
-    }
-}
-
-impl Connection<WebSocketBuilder> {
-    /// Initialize a new WebSocket connection.
-    #[instrument(skip(tx_ws, http_req))]
-    pub(crate) fn with_ws(
-        id: Id,
-        tx_ws: Sender<ProtoMessage>,
-        http_req: ProtoHttpRequest,
-    ) -> Result<ConnectionHandle, ConnectionError> {
-        let (ws_builder, write_handle) = WebSocketBuilder::with_handle(http_req)?;
-        let con = Self::new(id, tx_ws, ws_builder);
-        Ok(con.spawn(write_handle))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        http::Http, ConnectionError, ConnectionHandle, Id, ProtoHttpRequest, ProtoMessage,
-        ProtoWebSocketMessage, Transport, WriteHandle, WS_CHANNEL_SIZE,
+        http::Http, ConnectionError, ConnectionHandle, Id, ProtoMessage, ProtoWebSocketMessage,
+        Transport, WriteHandle, WS_CHANNEL_SIZE,
     };
-    use crate::messages::Http as ProtoHttp;
-    use crate::messages::{HttpMessage as ProtoHttpMessage, WebSocket as ProtoWebSocket};
+
+    use crate::messages::{
+        Http as ProtoHttp, HttpMessage as ProtoHttpMessage, HttpRequest as ProtoHttpRequest,
+        WebSocket as ProtoWebSocket,
+    };
 
     use http::header::CONTENT_TYPE;
     use http::HeaderValue;

--- a/edgehog-device-runtime-forwarder/src/connection/mod.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/mod.rs
@@ -6,22 +6,22 @@
 //! A connection is responsible for sending and receiving data through a WebSocket connection from
 //! and to the [`ConnectionsManager`](crate::connections_manager::ConnectionsManager).
 
-use std::ops::{ControlFlow, Deref, DerefMut};
+pub mod http;
+pub mod websocket;
+
+use std::ops::{Deref, DerefMut};
 
 use async_trait::async_trait;
-use futures::{SinkExt, StreamExt};
-use http::Request;
 use thiserror::Error as ThisError;
-use tokio::select;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::Sender;
 use tokio::task::{JoinError, JoinHandle};
-use tokio_tungstenite::tungstenite::{Error as TungError, Message as TungMessage};
-use tracing::{debug, error, instrument, trace};
+use tracing::{error, instrument, trace};
+use tokio_tungstenite::tungstenite::Error as TungError;
 
-use crate::connections_manager::WsStream;
+use self::http::HttpBuilder;
+use self::websocket::WebSocketBuilder;
 use crate::messages::{
-    Http as ProtoHttp, HttpMessage as ProtoHttpMessage, HttpRequest as ProtoHttpRequest,
-    HttpResponse as ProtoHttpResponse, Id, ProtoMessage, ProtocolError,
+    HttpRequest as ProtoHttpRequest, Id, ProtoMessage, ProtocolError,
     WebSocketMessage as ProtoWebSocketMessage,
 };
 
@@ -116,227 +116,6 @@ pub(crate) trait TransportBuilder {
 #[async_trait]
 pub(crate) trait Transport {
     async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError>;
-}
-
-/// Builder for an [`Http`] connection.
-#[derive(Debug)]
-
-pub(crate) struct HttpBuilder {
-    /// To send the request the builder must be consumed, so the option can be replaced with None
-    request: reqwest::RequestBuilder,
-}
-
-impl HttpBuilder {
-    fn new(request: reqwest::RequestBuilder) -> Self {
-        Self { request }
-    }
-}
-
-#[async_trait]
-impl TransportBuilder for HttpBuilder {
-    type Connection = Http;
-
-    /// The id and the channel are only useful for [`WebSocket`] connections.
-    async fn build(
-        self,
-        _id: &Id,
-        _tx_ws: Sender<ProtoMessage>,
-    ) -> Result<Self::Connection, ConnectionError> {
-        Ok(Http::new(self.request))
-    }
-}
-
-impl TryFrom<ProtoHttpRequest> for HttpBuilder {
-    type Error = ConnectionError;
-
-    fn try_from(value: ProtoHttpRequest) -> Result<Self, Self::Error> {
-        value
-            .request_builder()
-            .map(HttpBuilder::new)
-            .map_err(ConnectionError::from)
-    }
-}
-
-/// HTTP connection protocol
-#[derive(Debug)]
-pub(crate) struct Http {
-    /// To send the request the builder must be consumed, so the option can be replaced with None.
-    request: Option<reqwest::RequestBuilder>,
-}
-
-impl Http {
-    /// Store the HTTP request the connection will respond to once executed.
-    pub(crate) fn new(request: reqwest::RequestBuilder) -> Self {
-        Self {
-            request: Some(request),
-        }
-    }
-}
-
-#[async_trait]
-impl Transport for Http {
-    /// Send the [HTTP request](reqwest::Request), wait for a response and return it.
-    #[instrument(skip(self))]
-    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
-        let Some(request) = self.request.take() else {
-            return Ok(None);
-        };
-
-        trace!("sending HTTP request");
-        let http_res = request.send().await?;
-
-        // create the protobuf response to send to the bridge
-        let proto_res = ProtoHttpResponse::from_reqw_response(http_res).await?;
-
-        debug!("response code {}", proto_res.status());
-
-        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
-            id.clone(),
-            ProtoHttpMessage::Response(proto_res),
-        ));
-
-        Ok(Some(proto_msg))
-    }
-}
-
-/// Builder for an [`WebSocket`] connection.
-#[derive(Debug)]
-pub(crate) struct WebSocketBuilder {
-    request: Request<()>,
-    rx_con: Receiver<ProtoWebSocketMessage>,
-}
-
-impl WebSocketBuilder {
-    /// Upgrade the HTTP request and build the channel used to send WebSocket messages to device
-    /// services (e.g., TTYD).
-    fn with_handle(http_req: ProtoHttpRequest) -> Result<(Self, WriteHandle), ConnectionError> {
-        let request = http_req.ws_upgrade()?;
-        trace!("HTTP request upgraded");
-
-        // this channel that will be used to send data from the manager to the websocket connection
-        let (tx_con, rx_con) = channel::<ProtoWebSocketMessage>(WS_CHANNEL_SIZE);
-
-        Ok((Self { request, rx_con }, WriteHandle::Ws(tx_con)))
-    }
-}
-
-#[async_trait]
-impl TransportBuilder for WebSocketBuilder {
-    type Connection = WebSocket;
-
-    #[instrument(skip(self, tx_ws))]
-    async fn build(
-        self,
-        id: &Id,
-        tx_ws: Sender<ProtoMessage>,
-    ) -> Result<Self::Connection, ConnectionError> {
-        // establish a WebSocket connection
-        let (ws_stream, http_res) = tokio_tungstenite::connect_async(self.request).await?;
-        trace!("WebSocket stream for ID {id} created");
-
-        // send a ProtoMessage with the HTTP generated response to the connections manager
-        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
-            id.clone(),
-            ProtoHttpMessage::Response(ProtoHttpResponse::try_from(http_res)?),
-        ));
-
-        tx_ws.send(proto_msg).await.map_err(|_| {
-            ConnectionError::Channel(
-                "error while returning the Http upgrade response to the ConnectionsManager",
-            )
-        })?;
-
-        Ok(WebSocket::new(ws_stream, self.rx_con))
-    }
-}
-
-/// WebSocket connection protocol.
-#[derive(Debug)]
-pub(crate) struct WebSocket {
-    ws_stream: WsStream,
-    rx_con: Receiver<ProtoWebSocketMessage>,
-}
-
-#[async_trait]
-impl Transport for WebSocket {
-    /// Write/Read to/from a WebSocket.
-    ///
-    /// Returns a result only when the device receives a message from a WebSocket connection.
-    /// If a message needs to be forwarded to the device's WebSocket connection, a recursive
-    /// function call will be invoked.
-    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
-        match self.select().await {
-            // message from internal websocket connection (e.g., with TTYD) to the connections manager
-            WsEither::Read(tung_res) => self.handle_ws_read(id.clone(), tung_res).await,
-            // message from the connections manager to the internal websocket connection
-            WsEither::Write(chan_data) => {
-                if let ControlFlow::Break(()) = self.handle_ws_write(chan_data).await? {
-                    return Ok(None);
-                }
-                self.next(id).await
-            }
-        }
-    }
-}
-
-impl WebSocket {
-    fn new(ws_stream: WsStream, rx_con: Receiver<ProtoWebSocketMessage>) -> Self {
-        Self { ws_stream, rx_con }
-    }
-
-    /// The device can either receive a message from the WebSocket connection or may need to
-    /// forward data to it.
-    async fn select(&mut self) -> WsEither {
-        select! {
-            tung_res = self.ws_stream.next() => WsEither::Read(tung_res),
-            chan_data = self.rx_con.recv() => WsEither::Write(chan_data)
-        }
-    }
-
-    /// Handle the reception of new data from a WebSocket connection.
-    #[instrument(skip(self, tung_res))]
-    async fn handle_ws_read(
-        &mut self,
-        id: Id,
-        tung_res: Option<Result<TungMessage, TungError>>,
-    ) -> Result<Option<ProtoMessage>, ConnectionError> {
-        match tung_res {
-            // ws stream closed
-            None => {
-                debug!("ws stream {id} has been closed, exit");
-                Ok(None)
-            }
-            Some(Ok(tung_msg)) => Ok(Some(ProtoMessage::try_from_tung(id, tung_msg)?)),
-            Some(Err(err)) => Err(err.into()),
-        }
-    }
-
-    /// Forward data from the [`ConnectionsManager`](crate::connections_manager::ConnectionsManager)
-    /// to the device WebSocket connection.
-    #[instrument(skip_all)]
-    async fn handle_ws_write(
-        &mut self,
-        chan_data: Option<ProtoWebSocketMessage>,
-    ) -> Result<ControlFlow<()>, ConnectionError> {
-        // convert the websocket proto message into a Tung message
-        match chan_data {
-            None => {
-                debug!("channel dropped, closing connection");
-                Ok(ControlFlow::Break(()))
-            }
-            Some(ws_msg) => {
-                self.ws_stream.send(ws_msg.into()).await?;
-                trace!("message sent to TTYD");
-                Ok(ControlFlow::Continue(()))
-            }
-        }
-    }
-}
-
-/// Utility enum to avoid having too much code in the [`select`] macro branches.
-enum WsEither {
-    Read(Option<Result<TungMessage, TungError>>),
-    Write(Option<ProtoWebSocketMessage>),
 }
 
 /// Struct containing a connection information useful to communicate with the
@@ -434,12 +213,18 @@ impl Connection<WebSocketBuilder> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::messages::WebSocket as ProtoWebSocket;
+    use super::{
+        http::Http, ConnectionError, ConnectionHandle, Id, ProtoHttpRequest, ProtoMessage,
+        ProtoWebSocketMessage, Transport, WriteHandle, WS_CHANNEL_SIZE,
+    };
+    use crate::messages::Http as ProtoHttp;
+    use crate::messages::{HttpMessage as ProtoHttpMessage, WebSocket as ProtoWebSocket};
+
     use http::header::CONTENT_TYPE;
     use http::HeaderValue;
     use httpmock::Method::GET;
     use httpmock::MockServer;
+    use tokio::sync::mpsc::channel;
     use url::Url;
 
     async fn empty_task() {}

--- a/edgehog-device-runtime-forwarder/src/connection/mod.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/mod.rs
@@ -293,7 +293,7 @@ mod tests {
             connection: WriteHandle::Ws(tx),
         };
 
-        let proto_msg = create_http_req_msg_proto("https://host:8080/path?session_token=abcd");
+        let proto_msg = create_http_req_msg_proto("https://host:8080/path?session=abcd");
         let res = con_handle.send(proto_msg).await;
 
         assert!(matches!(res, Err(ConnectionError::WrongProtocol)));
@@ -306,13 +306,13 @@ mod tests {
         let mock_http_req = mock_server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/path")
-                .query_param("session_token", "abcd");
+                .query_param("session", "abcd");
             then.status(200)
                 .header("content-type", "text/html")
                 .body("body");
         });
 
-        let url = mock_server.url("/path?session_token=abcd");
+        let url = mock_server.url("/path?session=abcd");
 
         let url = Url::parse(&url).expect("failed to parse Url");
         let http_rep = create_http_req_proto(url);

--- a/edgehog-device-runtime-forwarder/src/connection/websocket.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/websocket.rs
@@ -1,0 +1,163 @@
+// Copyright 2023 SECO Mind Srl
+// SPDX-License-Identifier: Apache-2.0
+
+//! Define the necessary structs and traits to represent a WebSocket connection.
+
+use std::ops::ControlFlow;
+
+use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
+use http::Request;
+use tokio::select;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio_tungstenite::tungstenite::{Error as TungError, Message as TungMessage};
+use tracing::{debug, instrument, trace};
+
+use super::{ConnectionError, Transport, TransportBuilder, WriteHandle, WS_CHANNEL_SIZE};
+use crate::connections_manager::WsStream;
+use crate::messages::{
+    Http as ProtoHttp, HttpMessage as ProtoHttpMessage, HttpRequest as ProtoHttpRequest,
+    HttpResponse as ProtoHttpResponse, Id, ProtoMessage, WebSocketMessage as ProtoWebSocketMessage,
+};
+
+/// Builder for an [`WebSocket`] connection.
+#[derive(Debug)]
+pub(crate) struct WebSocketBuilder {
+    request: Request<()>,
+    rx_con: Receiver<ProtoWebSocketMessage>,
+}
+
+impl WebSocketBuilder {
+    /// Upgrade the HTTP request and build the channel used to send WebSocket messages to device
+    /// services (e.g., TTYD).
+    pub(crate) fn with_handle(
+        http_req: ProtoHttpRequest,
+    ) -> Result<(Self, WriteHandle), ConnectionError> {
+        let request = http_req.ws_upgrade()?;
+        trace!("HTTP request upgraded");
+
+        // this channel that will be used to send data from the manager to the websocket connection
+        let (tx_con, rx_con) = channel::<ProtoWebSocketMessage>(WS_CHANNEL_SIZE);
+
+        Ok((Self { request, rx_con }, WriteHandle::Ws(tx_con)))
+    }
+}
+
+#[async_trait]
+impl TransportBuilder for WebSocketBuilder {
+    type Connection = WebSocket;
+
+    #[instrument(skip(self, tx_ws))]
+    async fn build(
+        self,
+        id: &Id,
+        tx_ws: Sender<ProtoMessage>,
+    ) -> Result<Self::Connection, ConnectionError> {
+        // establish a WebSocket connection
+        let (ws_stream, http_res) = tokio_tungstenite::connect_async(self.request).await?;
+        trace!("WebSocket stream for ID {id} created");
+
+        // send a ProtoMessage with the HTTP generated response to the connections manager
+        let proto_msg = ProtoMessage::Http(ProtoHttp::new(
+            id.clone(),
+            ProtoHttpMessage::Response(ProtoHttpResponse::try_from(http_res)?),
+        ));
+
+        tx_ws.send(proto_msg).await.map_err(|_| {
+            ConnectionError::Channel(
+                "error while returning the Http upgrade response to the ConnectionsManager",
+            )
+        })?;
+
+        Ok(WebSocket::new(ws_stream, self.rx_con))
+    }
+}
+
+/// WebSocket connection protocol.
+#[derive(Debug)]
+pub(crate) struct WebSocket {
+    ws_stream: WsStream,
+    rx_con: Receiver<ProtoWebSocketMessage>,
+}
+
+#[async_trait]
+impl Transport for WebSocket {
+    /// Write/Read to/from a WebSocket.
+    ///
+    /// Returns a result only when the device receives a message from a WebSocket connection.
+    /// If a message needs to be forwarded to the device's WebSocket connection, a recursive
+    /// function call will be invoked.
+    async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
+        match self.select().await {
+            // message from internal websocket connection (e.g., with TTYD) to the connections manager
+            WsEither::Read(tung_res) => self.handle_ws_read(id.clone(), tung_res).await,
+            // message from the connections manager to the internal websocket connection
+            WsEither::Write(chan_data) => {
+                if let ControlFlow::Break(()) = self.handle_ws_write(chan_data).await? {
+                    return Ok(None);
+                }
+                self.next(id).await
+            }
+        }
+    }
+}
+
+impl WebSocket {
+    fn new(ws_stream: WsStream, rx_con: Receiver<ProtoWebSocketMessage>) -> Self {
+        Self { ws_stream, rx_con }
+    }
+
+    /// The device can either receive a message from the WebSocket connection or may need to
+    /// forward data to it.
+    async fn select(&mut self) -> WsEither {
+        select! {
+            tung_res = self.ws_stream.next() => WsEither::Read(tung_res),
+            chan_data = self.rx_con.recv() => WsEither::Write(chan_data)
+        }
+    }
+
+    /// Handle the reception of new data from a WebSocket connection.
+    #[instrument(skip(self, tung_res))]
+    async fn handle_ws_read(
+        &mut self,
+        id: Id,
+        tung_res: Option<Result<TungMessage, TungError>>,
+    ) -> Result<Option<ProtoMessage>, ConnectionError> {
+        match tung_res {
+            // ws stream closed
+            None => {
+                debug!("ws stream {id} has been closed, exit");
+                Ok(None)
+            }
+            Some(Ok(tung_msg)) => Ok(Some(ProtoMessage::try_from_tung(id, tung_msg)?)),
+            Some(Err(err)) => Err(err.into()),
+        }
+    }
+
+    /// Forward data from the [`ConnectionsManager`](crate::connections_manager::ConnectionsManager)
+    /// to the device WebSocket connection.
+    #[instrument(skip_all)]
+    async fn handle_ws_write(
+        &mut self,
+        chan_data: Option<ProtoWebSocketMessage>,
+    ) -> Result<ControlFlow<()>, ConnectionError> {
+        // convert the websocket proto message into a Tung message
+        match chan_data {
+            None => {
+                debug!("channel dropped, closing connection");
+                Ok(ControlFlow::Break(()))
+            }
+            Some(ws_msg) => {
+                self.ws_stream.send(ws_msg.into()).await?;
+                trace!("message sent to TTYD");
+                Ok(ControlFlow::Continue(()))
+            }
+        }
+    }
+}
+
+/// Utility enum to avoid having too much code in the [`select`] macro branches.
+enum WsEither {
+    Read(Option<Result<TungMessage, TungError>>),
+    Write(Option<ProtoWebSocketMessage>),
+}

--- a/edgehog-device-runtime-forwarder/src/connection/websocket.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/websocket.rs
@@ -93,16 +93,11 @@ impl Transport for WebSocket {
     /// If a message needs to be forwarded to the device's WebSocket connection, a recursive
     /// function call will be invoked.
     async fn next(&mut self, id: &Id) -> Result<Option<ProtoMessage>, ConnectionError> {
-        debug!("-------------NEXT---------------");
         match self.select().await {
             // message from internal websocket connection (e.g., with TTYD) to the connections manager
-            WsEither::Read(tung_res) => {
-                debug!("READ: {tung_res:?}");
-                self.handle_ws_read(id.clone(), tung_res).await
-            }
+            WsEither::Read(tung_res) => self.handle_ws_read(id.clone(), tung_res).await,
             // message from the connections manager to the internal websocket connection
             WsEither::Write(chan_data) => {
-                debug!("WRITE: {chan_data:?}");
                 if let ControlFlow::Break(()) = self.handle_ws_write(chan_data).await? {
                     return Ok(None);
                 }

--- a/edgehog-device-runtime-forwarder/src/connection/websocket.rs
+++ b/edgehog-device-runtime-forwarder/src/connection/websocket.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 SECO Mind Srl
+// Copyright 2024 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
 //! Define the necessary structs and traits to represent a WebSocket connection.

--- a/edgehog-device-runtime-forwarder/src/connections_manager.rs
+++ b/edgehog-device-runtime-forwarder/src/connections_manager.rs
@@ -61,11 +61,12 @@ pub struct Disconnected(#[from] pub TungError);
 /// WebSocket stream alias.
 pub type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
-/// Handler responsible for establishing a WebSocket connection between a device and Edgehog
-/// and for receiving and sending data from/to it.
+/// Handler responsible for
+/// - establishing a WebSocket connection between a device and Edgehog
+/// - receiving and sending data from/to it.
 #[derive(Debug)]
 pub struct ConnectionsManager {
-    /// Collection of connections, each identified by an ID.
+    /// Collection of connections.
     pub(crate) connections: Connections,
     /// Websocket stream between the device and Edgehog.
     pub(crate) ws_stream: WsStream,
@@ -90,9 +91,10 @@ impl ConnectionsManager {
 
         let ws_stream = Self::ws_connect(&url, connector).await?;
 
-        // this channel is used by tasks associated to the current session to exchange
-        // available information on a given WebSocket between the device and TTYD.
-        // it is also used to forward the incoming data from TTYD to the device.
+        // this channel is used by tasks associated with the current bridge-device session to exchange
+        // available information on a given connection between the device and another service.
+        // For instance, a device may have started a connection with a ttyd, a service used
+        // for sharing a remote terminal over a WebSocket interface.
         let (tx_ws, rx_ws) = channel(CHANNEL_SIZE);
 
         let connections = Connections::new(tx_ws);
@@ -112,7 +114,7 @@ impl ConnectionsManager {
         url: &Url,
         connector: Connector,
     ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Error> {
-        // try opening a WebSocket connection with Edgehog using exponential backoff
+        // try opening a WebSocket connection using exponential backoff
         let (ws_stream, http_res) =
             backoff::future::retry(ExponentialBackoff::default(), || async {
                 debug!("creating WebSocket connection with {}", url);
@@ -152,31 +154,26 @@ impl ConnectionsManager {
         Ok(ws_stream)
     }
 
-    /// Manage the reception and transmission of data between the WebSocket and each connection.
-    ///
-    /// It performs specific operations depending on the occurrence of one of the following events:
-    /// * Receiving data from the WebSocket,
-    /// * A timeout event occurring before any data is received from the WebSocket connection,
-    /// * Receiving data from one of the connections (e.g., between the device and TTYD).
+    /// Manage the reception and transmission of data between the WebSocket and each device connection.
     #[instrument(skip_all)]
     pub async fn handle_connections(&mut self) -> Result<(), Disconnected> {
         loop {
             match self.event_loop().await {
                 Ok(ControlFlow::Continue(())) => {}
-                // if the device received a message bigger than the maximum size, drop the message
-                // but keep looping for next events
-                Err(TungError::Capacity(err)) => {
-                    error!("capacity exceeded: {err}");
-                }
                 // if a close frame has been received or the closing handshake is correctly
                 // terminated, the manager terminates the handling of the connections
                 Ok(ControlFlow::Break(())) | Err(TungError::ConnectionClosed) => break,
-                // if the connection has been suddenly interrupted, try re-establishing it.
-                // only Tungstenite errors should be handled for device reconnection
+                // if the device received a message bigger than the maximum size, notify the error
+                Err(TungError::Capacity(err)) => {
+                    error!("capacity exceeded: {err}");
+                    break;
+                }
                 Err(TungError::AlreadyClosed) => {
                     error!("BUG: trying to read/write on an already closed WebSocket");
                     break;
                 }
+                // if the connection has been suddenly interrupted, try re-establishing it.
+                // only Tungstenite errors should be handled for device reconnection
                 Err(err) => {
                     return Err(Disconnected(err));
                 }
@@ -187,6 +184,10 @@ impl ConnectionsManager {
     }
 
     /// Handle a single connection event.
+    ///
+    /// It performs specific operations depending on the occurrence of one of the following events:
+    /// * Receiving data from the Edgehog-device WebSocket connection,
+    /// * Receiving data from one of the device connections (e.g., between the device and TTYD).
     #[instrument(skip_all)]
     pub(crate) async fn event_loop(&mut self) -> Result<ControlFlow<()>, TungError> {
         let event = self.select_ws_event().await;
@@ -198,7 +199,7 @@ impl ConnectionsManager {
                     .and_then(|msg| self.handle_tung_msg(msg))
                     .await
             }
-            // receive data from a connection (e.g., TTYD)
+            // receive data from a device connection (e.g., TTYD)
             WebSocketEvents::Send(tung_msg) => {
                 let msg = match tung_msg.encode() {
                     Ok(msg) => TungMessage::Binary(msg),
@@ -222,18 +223,18 @@ impl ConnectionsManager {
             res = self.ws_stream.next() => {
                 match res {
                     Some(msg) => {
-                        trace!("forwarding received tungstenite message: {msg:?}");
+                        trace!("received tungstenite message from Edgehog: {msg:?}");
                         WebSocketEvents::Receive(msg)
                     }
                     None => {
-                        trace!("ws stream next() returned None, connection already closed");
+                        trace!("ws_stream next() returned None, connection already closed");
                         WebSocketEvents::Receive(Err(TungError::AlreadyClosed))
                     }
                 }
             }
             next = self.rx_ws.recv() => match next {
                 Some(msg) => {
-                    trace!("forwarding proto message received from a device connection: {msg:?}");
+                    trace!("proto message received from a device connection: {msg:?}");
                     WebSocketEvents::Send(msg)
                 }
                 None => unreachable!("BUG: tx_ws channel should never be closed"),
@@ -259,9 +260,9 @@ impl ConnectionsManager {
                 let msg = TungMessage::Pong(data);
                 self.send_to_ws(msg).await?;
             }
-            TungMessage::Pong(_) => debug!("received Pong frame"),
+            TungMessage::Pong(_) => debug!("received pong"),
             TungMessage::Close(close_frame) => {
-                debug!("WebSocket close frame {close_frame:?}, closing active connections");
+                debug!("received close frame {close_frame:?}, closing active connections");
                 self.disconnect();
                 info!("closed every connection");
                 return Ok(ControlFlow::Break(()));
@@ -289,12 +290,11 @@ impl ConnectionsManager {
         Ok(ControlFlow::Continue(()))
     }
 
-    /// Handle a [`protobuf message`](ProtoMessage).
+    /// Handle a [`protocol message`](ProtoMessage).
     pub(crate) async fn handle_proto_msg(&mut self, proto_msg: ProtoMessage) -> Result<(), Error> {
         // remove from the collection all the terminated connections
         self.connections.remove_terminated();
 
-        // handle only HTTP requests, not other kind of protobuf messages
         match proto_msg {
             ProtoMessage::Http(http) => {
                 trace!("received HTTP message: {http:?}");
@@ -321,7 +321,6 @@ impl ConnectionsManager {
         self.ws_stream = Self::ws_connect(&self.url, connector).await?;
 
         info!("reconnected");
-
         Ok(())
     }
 
@@ -332,6 +331,7 @@ impl ConnectionsManager {
     }
 }
 
+/// Retrieve the session token query parameter from an URL
 pub(crate) fn get_token(url: &Url) -> Result<String, Error> {
     url.query()
         .map(|s| s.trim_start_matches("session=").to_string())

--- a/edgehog-device-runtime-forwarder/src/lib.rs
+++ b/edgehog-device-runtime-forwarder/src/lib.rs
@@ -16,3 +16,6 @@ pub mod tls;
 
 // re-exported dependencies
 pub use astarte_device_sdk;
+
+#[cfg(feature = "_test-utils")]
+pub mod test_utils;

--- a/edgehog-device-runtime-forwarder/src/messages.rs
+++ b/edgehog-device-runtime-forwarder/src/messages.rs
@@ -135,7 +135,7 @@ impl ProtoMessage {
         }))
     }
 
-    /// Return the internal websocket message if it matches the type.
+    /// Return the internal WebSocket message if it matches the type.
     pub(crate) fn into_ws(self) -> Option<WebSocket> {
         match self {
             ProtoMessage::Http(_) => None,
@@ -345,7 +345,7 @@ impl HttpRequest {
         )
         .parse()?;
 
-        // remove unsupported websocket headers
+        // remove unsupported WebSocket headers
         self.remove_unsupported_ws_ext();
 
         // add method
@@ -367,13 +367,13 @@ impl HttpRequest {
         req.body(()).map_err(ProtocolError::from)
     }
 
-    /// Remove unsupported websocket headers.
+    /// Remove unsupported WebSocket headers.
     #[instrument(skip_all)]
     fn remove_unsupported_ws_ext(&mut self) {
         // TODO: at the moment TTYD permessage-deflate extension is not supported by tungstenite. We should filter the supported ones implemented in tungstenite
         if let Some(extensions) = self.headers.remove("sec-websocket-extensions") {
             debug!(
-                "websocket extensions removed: {}",
+                "WebSocket extensions removed: {}",
                 String::from_utf8_lossy(extensions.as_bytes())
             );
         }
@@ -483,7 +483,7 @@ impl TryFrom<http::Response<Option<Vec<u8>>>> for HttpResponse {
     }
 }
 
-/// WebSocket request fields.
+/// WebSocket message fields.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct WebSocket {
     pub(crate) socket_id: Id,

--- a/edgehog-device-runtime-forwarder/src/messages.rs
+++ b/edgehog-device-runtime-forwarder/src/messages.rs
@@ -6,6 +6,7 @@
 //! The structures belonging to this module are used to serialize/deserialize to/from the protobuf
 //! data representation.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::num::TryFromIntError;
@@ -13,18 +14,20 @@ use std::ops::Not;
 use std::str::FromStr;
 
 use thiserror::Error as ThisError;
+use tokio_tungstenite::tungstenite::{Error as TungError, Message as TungMessage};
+use tracing::{debug, error, instrument, warn};
 use url::ParseError;
 
 use edgehog_device_forwarder_proto as proto;
 use edgehog_device_forwarder_proto::{
-    http::Message as ProtoHttpMessage,
-    http::Request as ProtoHttpRequest,
-    http::Response as ProtoHttpResponse,
-    message::Protocol as ProtoProtocol,
+    http::Message as ProtobufHttpMessage,
+    http::Request as ProtobufHttpRequest,
+    http::Response as ProtobufHttpResponse,
+    message::Protocol as ProtobufProtocol,
     prost::{self, Message as ProstMessage},
-    web_socket::Close as ProtoWsClose,
-    web_socket::Message as ProtoWsMessage,
-    Http as ProtoHttp, WebSocket as ProtoWebSocket,
+    web_socket::Close as ProtobufWsClose,
+    web_socket::Message as ProtobufWsMessage,
+    Http as ProtobufHttp, WebSocket as ProtobufWebSocket,
 };
 
 /// Errors occurring while handling [`protobuf`](https://protobuf.dev/overview/) messages
@@ -43,18 +46,26 @@ pub enum ProtocolError {
     ParseUrl(#[from] ParseError),
     /// Wrong HTTP method field.
     InvalidHttpMethod(#[from] http::method::InvalidMethod),
+    /// Invalid Uri.
+    InvalidUri(#[from] http::uri::InvalidUri),
     /// Http error.
     Http(#[from] http::Error),
     /// Invalid HTTP status code
     InvalidStatusCode(#[from] http::status::InvalidStatusCode),
     /// Error while parsing Headers.
     ParseHeaders(#[from] http::header::ToStrError),
-    /// Invalid port number
+    /// Invalid port number.
     InvalidPortNumber(#[from] TryFromIntError),
+    /// Wrong HTTP method field, `{0}`.
+    WrongHttpMethod(String),
+    /// Error performing exponential backoff when trying to connect with TTYD, {0}
+    WebSocketConnect(#[from] TungError),
+    /// Received a wrong WebSocket frame.
+    WrongWsFrame,
 }
 
 /// Requests Id.
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Default, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Id(Vec<u8>);
 
 impl Debug for Id {
@@ -93,7 +104,7 @@ pub(crate) enum ProtoMessage {
 impl ProtoMessage {
     /// Encode [`ProtoMessage`] struct into the corresponding [`protobuf`](https://protobuf.dev/overview/) version.
     pub(crate) fn encode(self) -> Result<Vec<u8>, ProtocolError> {
-        let protocol = ProtoProtocol::from(self);
+        let protocol = ProtobufProtocol::from(self);
 
         let msg = proto::Message {
             protocol: Some(protocol),
@@ -110,6 +121,34 @@ impl ProtoMessage {
         let msg = proto::Message::decode(bytes).map_err(ProtocolError::from)?;
         Self::try_from(msg)
     }
+
+    /// Convert a Tungstenite frame into a ProtoMessage
+    pub(crate) fn try_from_tung(
+        socket_id: Id,
+        tung_msg: TungMessage,
+    ) -> Result<Self, ProtocolError> {
+        Ok(Self::WebSocket(WebSocket {
+            socket_id,
+            message: WebSocketMessage::try_from(tung_msg)?,
+        }))
+    }
+
+    /// Return the internal websocket message if it matches the type.
+    pub(crate) fn into_ws(self) -> Option<WebSocket> {
+        match self {
+            ProtoMessage::Http(_) => None,
+            ProtoMessage::WebSocket(ws) => Some(ws),
+        }
+    }
+
+    /// Return the internal http message if it matches the type.
+    #[cfg(test)]
+    pub(crate) fn into_http(self) -> Option<Http> {
+        match self {
+            ProtoMessage::Http(http) => Some(http),
+            ProtoMessage::WebSocket(_) => None,
+        }
+    }
 }
 
 impl TryFrom<proto::Message> for ProtoMessage {
@@ -124,30 +163,30 @@ impl TryFrom<proto::Message> for ProtoMessage {
     }
 }
 
-impl TryFrom<ProtoProtocol> for ProtoMessage {
+impl TryFrom<ProtobufProtocol> for ProtoMessage {
     type Error = ProtocolError;
 
-    fn try_from(value: ProtoProtocol) -> Result<Self, Self::Error> {
+    fn try_from(value: ProtobufProtocol) -> Result<Self, Self::Error> {
         let protocol = match value {
-            ProtoProtocol::Http(http) => ProtoMessage::Http(http.try_into()?),
-            ProtoProtocol::Ws(ws) => ProtoMessage::WebSocket(ws.try_into()?),
+            ProtobufProtocol::Http(http) => ProtoMessage::Http(http.try_into()?),
+            ProtobufProtocol::Ws(ws) => ProtoMessage::WebSocket(ws.try_into()?),
         };
 
         Ok(protocol)
     }
 }
 
-impl From<ProtoMessage> for ProtoProtocol {
+impl From<ProtoMessage> for ProtobufProtocol {
     fn from(protocol: ProtoMessage) -> Self {
         match protocol {
             ProtoMessage::Http(http) => {
-                let proto_http = ProtoHttp::from(http);
-                ProtoProtocol::Http(proto_http)
+                let proto_http = ProtobufHttp::from(http);
+                ProtobufProtocol::Http(proto_http)
             }
             ProtoMessage::WebSocket(ws) => {
-                let proto_ws = ProtoWebSocket::from(ws);
+                let proto_ws = ProtobufWebSocket::from(ws);
 
-                ProtoProtocol::Ws(proto_ws)
+                ProtobufProtocol::Ws(proto_ws)
             }
         }
     }
@@ -171,11 +210,11 @@ impl Http {
     }
 }
 
-impl TryFrom<ProtoHttp> for Http {
+impl TryFrom<ProtobufHttp> for Http {
     type Error = ProtocolError;
 
-    fn try_from(value: ProtoHttp) -> Result<Self, Self::Error> {
-        let ProtoHttp {
+    fn try_from(value: ProtobufHttp) -> Result<Self, Self::Error> {
+        let ProtobufHttp {
             request_id,
             message,
         } = value;
@@ -185,8 +224,8 @@ impl TryFrom<ProtoHttp> for Http {
         message
             .ok_or(ProtocolError::Empty)
             .and_then(|msg| match msg {
-                ProtoHttpMessage::Request(req) => req.try_into().map(HttpMessage::Request),
-                ProtoHttpMessage::Response(res) => res.try_into().map(HttpMessage::Response),
+                ProtobufHttpMessage::Request(req) => req.try_into().map(HttpMessage::Request),
+                ProtobufHttpMessage::Response(res) => res.try_into().map(HttpMessage::Response),
             })
             .map(|http_msg: HttpMessage| Http {
                 request_id,
@@ -195,16 +234,16 @@ impl TryFrom<ProtoHttp> for Http {
     }
 }
 
-impl From<Http> for ProtoHttp {
+impl From<Http> for ProtobufHttp {
     fn from(value: Http) -> Self {
         let message = match value.http_msg {
             HttpMessage::Request(req) => {
-                let proto_req = ProtoHttpRequest::from(req);
-                ProtoHttpMessage::Request(proto_req)
+                let proto_req = ProtobufHttpRequest::from(req);
+                ProtobufHttpMessage::Request(proto_req)
             }
             HttpMessage::Response(res) => {
-                let proto_res = ProtoHttpResponse::from(res);
-                ProtoHttpMessage::Response(proto_res)
+                let proto_res = ProtobufHttpResponse::from(res);
+                ProtobufHttpMessage::Response(proto_res)
             }
         };
 
@@ -222,16 +261,33 @@ pub(crate) enum HttpMessage {
     Response(HttpResponse),
 }
 
+impl HttpMessage {
+    pub(crate) fn into_req(self) -> Option<HttpRequest> {
+        match self {
+            HttpMessage::Request(req) => Some(req),
+            HttpMessage::Response(_) => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_res(self) -> Option<HttpResponse> {
+        match self {
+            HttpMessage::Request(_) => None,
+            HttpMessage::Response(res) => Some(res),
+        }
+    }
+}
+
 /// HTTP request fields.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct HttpRequest {
-    path: String,
-    query_string: String,
-    method: http::Method,
-    headers: http::HeaderMap,
-    body: Vec<u8>,
+    pub(crate) method: http::Method,
+    pub(crate) path: String,
+    pub(crate) query_string: String,
+    pub(crate) headers: http::HeaderMap,
+    pub(crate) body: Vec<u8>,
     /// Port on the device to which the request will be sent.
-    port: u16,
+    pub(crate) port: u16,
 }
 
 impl HttpRequest {
@@ -251,12 +307,69 @@ impl HttpRequest {
 
         Ok(http_builder)
     }
+
+    /// Check if the HTTP request contains an "Upgrade" header.
+    pub(crate) fn is_upgrade(&self) -> bool {
+        static WEBSOCKET_UPGRADE: http::HeaderValue = http::HeaderValue::from_static("websocket");
+
+        self.headers
+            .get_all(http::header::UPGRADE)
+            .iter()
+            .any(|v| v == WEBSOCKET_UPGRADE)
+    }
+
+    /// Convert an [`HttpRequest`] into an [`http::Request`](http::Request)
+    #[instrument(skip_all)]
+    pub(crate) fn upgrade(mut self) -> Result<http::Request<()>, ProtocolError> {
+        let uri: http::Uri = format!(
+            "ws://localhost:{}/{}?{}",
+            self.port, self.path, self.query_string
+        )
+        .parse()?;
+
+        // remove unsupported websocket headers
+        self.remove_unsupported_ws_ext();
+
+        // add method
+        let req = http::request::Builder::new().uri(uri).method(self.method);
+
+        // add the headers to the request
+        let req = self
+            .headers
+            .into_iter()
+            .fold(req, |req, (key, val)| match key {
+                Some(key) => req.header(key, val),
+                None => req,
+            });
+
+        // the body of an upgrade request should be empty.
+        if !self.body.is_empty() {
+            warn!(
+                "HTTP upgrade request contains non-empty body, {:?}",
+                self.body
+            );
+        }
+
+        req.body(()).map_err(ProtocolError::from)
+    }
+
+    /// Remove unsupported websocket headers.
+    #[instrument(skip_all)]
+    fn remove_unsupported_ws_ext(&mut self) {
+        // TODO: at the moment TTYD permessage-deflate extension is not supported by tungstenite. We should filter the supported ones implemented in tungstenite
+        if let Some(extensions) = self.headers.remove("sec-websocket-extensions") {
+            debug!(
+                "websocket extensions removed: {}",
+                String::from_utf8_lossy(extensions.as_bytes())
+            );
+        }
+    }
 }
 
-impl TryFrom<ProtoHttpRequest> for HttpRequest {
+impl TryFrom<ProtobufHttpRequest> for HttpRequest {
     type Error = ProtocolError;
-    fn try_from(value: ProtoHttpRequest) -> Result<Self, Self::Error> {
-        let ProtoHttpRequest {
+    fn try_from(value: ProtobufHttpRequest) -> Result<Self, Self::Error> {
+        let ProtobufHttpRequest {
             path,
             method,
             query_string,
@@ -275,7 +388,7 @@ impl TryFrom<ProtoHttpRequest> for HttpRequest {
     }
 }
 
-impl From<HttpRequest> for ProtoHttpRequest {
+impl From<HttpRequest> for ProtobufHttpRequest {
     fn from(http_req: HttpRequest) -> Self {
         Self {
             path: http_req.path,
@@ -291,35 +404,37 @@ impl From<HttpRequest> for ProtoHttpRequest {
 /// HTTP response fields.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct HttpResponse {
-    status_code: http::StatusCode,
-    headers: http::HeaderMap,
-    body: Vec<u8>,
+    pub(crate) status_code: http::StatusCode,
+    pub(crate) headers: http::HeaderMap,
+    pub(crate) body: Vec<u8>,
 }
 
 impl HttpResponse {
-    /// Create a new HTTP response.
-    pub(crate) fn new(
-        status_code: http::StatusCode,
-        headers: http::HeaderMap,
-        body: Vec<u8>,
-    ) -> Self {
-        Self {
-            status_code,
-            headers,
-            body,
-        }
-    }
-
     /// Return the status code of the HTTP response.
     pub(crate) fn status(&self) -> u16 {
         self.status_code.as_u16()
     }
+
+    /// Create an [`HttpResponse`] message from a [`reqwest`] response.
+    pub(crate) async fn from_reqw_response(
+        http_res: reqwest::Response,
+    ) -> Result<Self, reqwest::Error> {
+        let status_code = http_res.status();
+        let headers = http_res.headers().clone();
+        let body = http_res.bytes().await?.into();
+
+        Ok(Self {
+            status_code,
+            headers,
+            body,
+        })
+    }
 }
 
-impl TryFrom<ProtoHttpResponse> for HttpResponse {
+impl TryFrom<ProtobufHttpResponse> for HttpResponse {
     type Error = ProtocolError;
-    fn try_from(value: ProtoHttpResponse) -> Result<Self, Self::Error> {
-        let ProtoHttpResponse {
+    fn try_from(value: ProtobufHttpResponse) -> Result<Self, Self::Error> {
+        let ProtobufHttpResponse {
             status_code,
             headers,
             body,
@@ -333,7 +448,7 @@ impl TryFrom<ProtoHttpResponse> for HttpResponse {
     }
 }
 
-impl From<HttpResponse> for ProtoHttpResponse {
+impl From<HttpResponse> for ProtobufHttpResponse {
     fn from(http_res: HttpResponse) -> Self {
         Self {
             status_code: http_res.status_code.as_u16().into(),
@@ -343,17 +458,33 @@ impl From<HttpResponse> for ProtoHttpResponse {
     }
 }
 
+impl TryFrom<http::Response<Option<Vec<u8>>>> for HttpResponse {
+    type Error = ProtocolError;
+
+    fn try_from(mut value: http::Response<Option<Vec<u8>>>) -> Result<Self, Self::Error> {
+        let status_code = value.status();
+        let headers = value.headers().clone();
+        let body = value.body_mut().take().unwrap_or_default();
+
+        Ok(Self {
+            status_code,
+            headers,
+            body,
+        })
+    }
+}
+
 /// WebSocket request fields.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct WebSocket {
-    socket_id: Id,
-    message: WebSocketMessage,
+    pub(crate) socket_id: Id,
+    pub(crate) message: WebSocketMessage,
 }
 
-impl TryFrom<ProtoWebSocket> for WebSocket {
+impl TryFrom<ProtobufWebSocket> for WebSocket {
     type Error = ProtocolError;
 
-    fn try_from(value: ProtoWebSocket) -> Result<Self, Self::Error> {
+    fn try_from(value: ProtobufWebSocket) -> Result<Self, Self::Error> {
         let proto::WebSocket { socket_id, message } = value;
 
         let Some(msg) = message else {
@@ -361,11 +492,11 @@ impl TryFrom<ProtoWebSocket> for WebSocket {
         };
 
         let message = match msg {
-            ProtoWsMessage::Text(data) => WebSocketMessage::text(data),
-            ProtoWsMessage::Binary(data) => WebSocketMessage::binary(data),
-            ProtoWsMessage::Ping(data) => WebSocketMessage::ping(data),
-            ProtoWsMessage::Pong(data) => WebSocketMessage::pong(data),
-            ProtoWsMessage::Close(close) => WebSocketMessage::close(
+            ProtobufWsMessage::Text(data) => WebSocketMessage::text(data),
+            ProtobufWsMessage::Binary(data) => WebSocketMessage::binary(data),
+            ProtobufWsMessage::Ping(data) => WebSocketMessage::ping(data),
+            ProtobufWsMessage::Pong(data) => WebSocketMessage::pong(data),
+            ProtobufWsMessage::Close(close) => WebSocketMessage::close(
                 close.code.try_into()?,
                 close.reason.is_empty().not().then_some(close.reason),
             ),
@@ -378,14 +509,14 @@ impl TryFrom<ProtoWebSocket> for WebSocket {
     }
 }
 
-impl From<WebSocket> for ProtoWebSocket {
+impl From<WebSocket> for ProtobufWebSocket {
     fn from(ws: WebSocket) -> Self {
         let ws_message = match ws.message {
-            WebSocketMessage::Text(data) => ProtoWsMessage::Text(data),
-            WebSocketMessage::Binary(data) => ProtoWsMessage::Binary(data),
-            WebSocketMessage::Ping(data) => ProtoWsMessage::Ping(data),
-            WebSocketMessage::Pong(data) => ProtoWsMessage::Pong(data),
-            WebSocketMessage::Close { code, reason } => ProtoWsMessage::Close(ProtoWsClose {
+            WebSocketMessage::Text(data) => ProtobufWsMessage::Text(data),
+            WebSocketMessage::Binary(data) => ProtobufWsMessage::Binary(data),
+            WebSocketMessage::Ping(data) => ProtobufWsMessage::Ping(data),
+            WebSocketMessage::Pong(data) => ProtobufWsMessage::Pong(data),
+            WebSocketMessage::Close { code, reason } => ProtobufWsMessage::Close(ProtobufWsClose {
                 code: code.into(),
                 reason: reason.unwrap_or_default(),
             }),
@@ -435,6 +566,55 @@ impl WebSocketMessage {
     }
 }
 
+impl TryFrom<TungMessage> for WebSocketMessage {
+    type Error = ProtocolError;
+
+    fn try_from(tung_msg: TungMessage) -> Result<Self, Self::Error> {
+        let msg = match tung_msg {
+            TungMessage::Text(data) => WebSocketMessage::text(data),
+            TungMessage::Binary(data) => WebSocketMessage::binary(data),
+            TungMessage::Ping(data) => WebSocketMessage::ping(data),
+            TungMessage::Pong(data) => WebSocketMessage::pong(data),
+            TungMessage::Close(data) => {
+                // instead of returning an error, here i build a default close frame in case no frame is passed
+                let (code, reason) = match data {
+                    Some(close_frame) => {
+                        let code = close_frame.code.into();
+                        let reason = Some(close_frame.reason.into_owned());
+                        (code, reason)
+                    }
+                    None => (1000, None),
+                };
+
+                WebSocketMessage::close(code, reason)
+            }
+            TungMessage::Frame(_) => {
+                error!("this kind of message should not be sent");
+                return Err(ProtocolError::WrongWsFrame);
+            }
+        };
+
+        Ok(msg)
+    }
+}
+
+impl From<WebSocketMessage> for TungMessage {
+    fn from(value: WebSocketMessage) -> Self {
+        match value {
+            WebSocketMessage::Text(data) => Self::Text(data),
+            WebSocketMessage::Binary(data) => Self::Binary(data),
+            WebSocketMessage::Ping(data) => Self::Ping(data),
+            WebSocketMessage::Pong(data) => Self::Pong(data),
+            WebSocketMessage::Close { code, reason } => {
+                Self::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                    code: code.into(),
+                    reason: Cow::Owned(reason.unwrap_or_default()),
+                }))
+            }
+        }
+    }
+}
+
 /// Convert a [`HeaderMap`] containing all HTTP headers into a [`HashMap`].
 pub(crate) fn headermap_to_hashmap<'a, I>(headers: I) -> HashMap<String, String>
 where
@@ -473,10 +653,10 @@ mod tests {
         }
     }
 
-    fn empty_protobuf_http(id: &[u8]) -> ProtoHttp {
-        ProtoHttp {
+    fn empty_protobuf_http(id: &[u8]) -> ProtobufHttp {
+        ProtobufHttp {
             request_id: id.to_vec(),
-            message: Some(ProtoHttpMessage::Request(ProtoHttpRequest {
+            message: Some(ProtobufHttpMessage::Request(ProtobufHttpRequest {
                 body: Vec::new(),
                 headers: HashMap::new(),
                 query_string: String::new(),
@@ -487,10 +667,10 @@ mod tests {
         }
     }
 
-    fn empty_protobuf_ws(id: &[u8]) -> ProtoWebSocket {
-        ProtoWebSocket {
+    fn empty_protobuf_ws(id: &[u8]) -> ProtobufWebSocket {
+        ProtobufWebSocket {
             socket_id: id.to_vec(),
-            message: Some(ProtoWsMessage::Binary(b"test_data".to_vec())),
+            message: Some(ProtobufWsMessage::Binary(b"test_data".to_vec())),
         }
     }
 
@@ -521,7 +701,7 @@ mod tests {
     fn test_from_protobuf_protocol() {
         // test WebSocket match case
         let id = b"test_id".to_vec();
-        let proto = ProtoProtocol::Ws(empty_protobuf_ws(&id));
+        let proto = ProtobufProtocol::Ws(empty_protobuf_ws(&id));
         let res = ProtoMessage::try_from(proto).unwrap();
 
         let exp = ProtoMessage::WebSocket(WebSocket {
@@ -535,9 +715,9 @@ mod tests {
     #[test]
     fn test_try_from_protobuf_http() {
         // test response ok
-        let protobuf_msg = ProtoHttp {
+        let protobuf_msg = ProtobufHttp {
             request_id: b"test_id".to_vec(),
-            message: Some(ProtoHttpMessage::Response(ProtoHttpResponse {
+            message: Some(ProtobufHttpMessage::Response(ProtobufHttpResponse {
                 body: Vec::new(),
                 headers: HashMap::new(),
                 status_code: 200,
@@ -547,7 +727,7 @@ mod tests {
         assert!(Http::try_from(protobuf_msg).is_ok());
 
         // test missing message
-        let protobuf_msg = ProtoHttp {
+        let protobuf_msg = ProtobufHttp {
             request_id: b"test_id".to_vec(),
             message: None,
         };
@@ -564,7 +744,7 @@ mod tests {
 
         let expected = empty_protobuf_http(b"test_id");
 
-        assert_eq!(ProtoHttp::from(msg), expected);
+        assert_eq!(ProtobufHttp::from(msg), expected);
     }
 
     #[test]
@@ -581,7 +761,7 @@ mod tests {
     #[test]
     fn test_try_from_protobuf_websocket() {
         // empty ws message
-        let protobuf_msg = ProtoWebSocket {
+        let protobuf_msg = ProtobufWebSocket {
             socket_id: b"test_id".to_vec(),
             message: None,
         };
@@ -592,9 +772,9 @@ mod tests {
         ));
 
         // empty ID message
-        let protobuf_msg = ProtoWebSocket {
+        let protobuf_msg = ProtobufWebSocket {
             socket_id: Vec::new(),
-            message: Some(ProtoWsMessage::Binary(Vec::new())),
+            message: Some(ProtobufWsMessage::Binary(Vec::new())),
         };
 
         assert!(matches!(
@@ -605,23 +785,23 @@ mod tests {
         // check all variants
         let protobuf_msgs = [
             (
-                ProtoWsMessage::Text(String::new()),
+                ProtobufWsMessage::Text(String::new()),
                 WebSocketMessage::Text(String::new()),
             ),
             (
-                ProtoWsMessage::Binary(Vec::new()),
+                ProtobufWsMessage::Binary(Vec::new()),
                 WebSocketMessage::Binary(Vec::new()),
             ),
             (
-                ProtoWsMessage::Ping(Vec::new()),
+                ProtobufWsMessage::Ping(Vec::new()),
                 WebSocketMessage::Ping(Vec::new()),
             ),
             (
-                ProtoWsMessage::Pong(Vec::new()),
+                ProtobufWsMessage::Pong(Vec::new()),
                 WebSocketMessage::Pong(Vec::new()),
             ),
             (
-                ProtoWsMessage::Close(ProtoWsClose {
+                ProtobufWsMessage::Close(ProtobufWsClose {
                     code: 1000,
                     reason: String::new(),
                 }),
@@ -633,7 +813,7 @@ mod tests {
         ]
         .map(|(case, exp)| {
             (
-                ProtoWebSocket {
+                ProtobufWebSocket {
                     socket_id: b"test_id".to_vec(),
                     message: Some(case),
                 },
@@ -655,26 +835,26 @@ mod tests {
         let proto_msgs = [
             (
                 WebSocketMessage::Text(String::new()),
-                ProtoWsMessage::Text(String::new()),
+                ProtobufWsMessage::Text(String::new()),
             ),
             (
                 WebSocketMessage::Binary(Vec::new()),
-                ProtoWsMessage::Binary(Vec::new()),
+                ProtobufWsMessage::Binary(Vec::new()),
             ),
             (
                 WebSocketMessage::Ping(Vec::new()),
-                ProtoWsMessage::Ping(Vec::new()),
+                ProtobufWsMessage::Ping(Vec::new()),
             ),
             (
                 WebSocketMessage::Pong(Vec::new()),
-                ProtoWsMessage::Pong(Vec::new()),
+                ProtobufWsMessage::Pong(Vec::new()),
             ),
             (
                 WebSocketMessage::Close {
                     code: 1000,
                     reason: None,
                 },
-                ProtoWsMessage::Close(ProtoWsClose {
+                ProtobufWsMessage::Close(ProtobufWsClose {
                     code: 1000,
                     reason: String::new(),
                 }),
@@ -686,7 +866,7 @@ mod tests {
                     socket_id: Id::try_from(b"test_id".to_vec()).unwrap(),
                     message: case,
                 },
-                ProtoWebSocket {
+                ProtobufWebSocket {
                     socket_id: b"test_id".to_vec(),
                     message: Some(exp),
                 },
@@ -694,7 +874,7 @@ mod tests {
         });
 
         for (case, exp) in proto_msgs {
-            assert_eq!(ProtoWebSocket::from(case), exp);
+            assert_eq!(ProtobufWebSocket::from(case), exp);
         }
     }
 }

--- a/edgehog-device-runtime-forwarder/src/test_utils.rs
+++ b/edgehog-device-runtime-forwarder/src/test_utils.rs
@@ -247,7 +247,7 @@ impl TestConnections<MockServer> {
         let mock_server = MockServer::start();
 
         let (listener, port) = bind_port().await;
-        let url = format!("ws://localhost:{port}/remote-terminal?session_token=1234");
+        let url = format!("ws://localhost:{port}/remote-terminal?session=abcd");
 
         Self {
             mock_server,
@@ -262,7 +262,7 @@ impl TestConnections<MockServer> {
         self.mock_server.mock(|when, then| {
             when.method(GET)
                 .path("/remote-terminal")
-                .query_param("session_token", "abcd");
+                .query_param("session", "abcd");
             then.status(200)
                 .header("content-type", "text/html")
                 .body("just do it");
@@ -276,7 +276,7 @@ impl TestConnections<MockWebSocket> {
         let mock_server = MockWebSocket::start().await;
 
         let (listener, port) = bind_port().await;
-        let url = format!("ws://localhost:{port}/remote-terminal?session_token=1234");
+        let url = format!("ws://localhost:{port}/remote-terminal?session=abcd");
 
         Self {
             mock_server,

--- a/edgehog-device-runtime-forwarder/src/test_utils.rs
+++ b/edgehog-device-runtime-forwarder/src/test_utils.rs
@@ -60,7 +60,7 @@ fn proto_http_req(request_id: Vec<u8>, url: &Url, body: Vec<u8>) -> proto::Messa
     }
 }
 
-/// Create an HTTP request and wrap it into a [`tungstenite`] message.
+/// Create an HTTP request and wrap it into a [`tungstenite`](tokio_tungstenite::tungstenite) message.
 pub fn create_http_req(request_id: Vec<u8>, url: &str, body: Vec<u8>) -> TungMessage {
     let url = Url::parse(url).expect("failed to pars Url");
 
@@ -72,7 +72,7 @@ pub fn create_http_req(request_id: Vec<u8>, url: &str, body: Vec<u8>) -> TungMes
     TungMessage::Binary(buf)
 }
 
-/// Create an HTTP upgrade request and wrap it into a [`tungstenite`] message.
+/// Create an HTTP upgrade request and wrap it into a [`tungstenite`](tokio_tungstenite::tungstenite) message.
 pub fn create_http_upgrade_req(request_id: Vec<u8>, url: &str) -> TungMessage {
     let url = Url::parse(url).expect("failed to pars Url");
     let port = url.port().expect("nonexistent port").into();
@@ -122,7 +122,7 @@ pub fn is_ws_upgrade_response(http_msg: ProtobufHttpMessage) -> bool {
     }
 }
 
-/// Create a binary [`tungstenite`] message carrying a WebSocket frame.
+/// Create a binary [`tungstenite`](tokio_tungstenite::tungstenite) message carrying a WebSocket frame.
 pub fn create_ws_msg(socket_id: Vec<u8>, frame: TungMessage) -> TungMessage {
     let proto_msg = proto::Message {
         protocol: Some(ProtobufProtocol::Ws(ProtobufWebSocket {

--- a/edgehog-device-runtime-forwarder/src/test_utils.rs
+++ b/edgehog-device-runtime-forwarder/src/test_utils.rs
@@ -1,0 +1,329 @@
+// Copyright 2023 SECO Mind Srl
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module containing utility functions and structures to perform integration test of the library.
+
+use crate::connections_manager::{ConnectionsManager, Disconnected};
+
+use edgehog_device_forwarder_proto as proto;
+use edgehog_device_forwarder_proto::{
+    http::Message as ProtobufHttpMessage, http::Request as ProtobufHttpRequest,
+    message::Protocol as ProtobufProtocol, prost::Message,
+    web_socket::Message as ProtobufWsMessage, Http as ProtobufHttp, WebSocket as ProtobufWebSocket,
+};
+use futures::{SinkExt, StreamExt};
+use httpmock::prelude::*;
+use httpmock::Mock;
+use std::collections::HashMap;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::Message as TungMessage;
+use tokio_tungstenite::WebSocketStream;
+use tracing::{debug, instrument};
+use url::Url;
+
+/// Build a listener on a free port.
+pub async fn bind_port() -> (TcpListener, u16) {
+    let listener = TcpListener::bind("localhost:0")
+        .await
+        .expect("failed to create a tcp listener");
+
+    let port = listener
+        .local_addr()
+        .expect("failed to retrieve local addr")
+        .port();
+
+    (listener, port)
+}
+
+/// Start a [`ConnectionsManager`] instance.
+pub async fn con_manager(url: String, secure: bool) -> Result<(), Disconnected> {
+    let mut con_manager = ConnectionsManager::connect(url.as_str().try_into().unwrap(), secure)
+        .await
+        .expect("failed to connect connections manager");
+    con_manager.handle_connections().await
+}
+
+/// Create an HTTP request and wrap it into a [`tungstenite`] message.
+pub fn create_http_req(request_id: Vec<u8>, url: &str) -> TungMessage {
+    let url = Url::parse(url).expect("failed to pars Url");
+
+    let proto_msg = proto::Message {
+        protocol: Some(ProtobufProtocol::Http(ProtobufHttp {
+            request_id,
+            message: Some(ProtobufHttpMessage::Request(ProtobufHttpRequest {
+                path: url.path().trim_start_matches('/').to_string(),
+                method: "GET".to_string(),
+                query_string: url.query().unwrap_or_default().to_string(),
+                headers: HashMap::new(),
+                body: Vec::new(),
+                port: url.port().expect("nonexistent port").into(),
+            })),
+        })),
+    };
+
+    let mut buf = Vec::with_capacity(proto_msg.encoded_len());
+    proto_msg.encode(&mut buf).unwrap();
+
+    TungMessage::Binary(buf)
+}
+
+/// Create an HTTP upgrade request and wrap it into a [`tungstenite`] message.
+pub fn create_http_upgrade_req(request_id: Vec<u8>, url: &str) -> TungMessage {
+    let url = Url::parse(url).expect("failed to pars Url");
+    let port = url.port().expect("nonexistent port").into();
+
+    let mut headers = HashMap::new();
+    headers.insert("Host".to_string(), format!("localhost:{port}"));
+    headers.insert("Connection".to_string(), "keep-alive, Upgrade".to_string());
+    headers.insert("Upgrade".to_string(), "websocket".to_string());
+    headers.insert("Sec-WebSocket-Version".to_string(), "13".to_string());
+    headers.insert("Sec-WebSocket-Protocol".to_string(), "tty".to_string());
+    headers.insert(
+        "Seco-WebSocket-Extensions".to_string(),
+        "permessage-deflate".to_string(),
+    );
+    headers.insert(
+        "Sec-WebSocket-Key".to_string(),
+        "KZFI7tLjyq4dy8TqCPDRzA==".to_string(),
+    );
+
+    let proto_msg = proto::Message {
+        protocol: Some(ProtobufProtocol::Http(ProtobufHttp {
+            request_id,
+            message: Some(ProtobufHttpMessage::Request(ProtobufHttpRequest {
+                path: url.path().trim_start_matches('/').to_string(),
+                method: "GET".to_string(),
+                query_string: url.query().unwrap_or_default().to_string(),
+                headers,
+                body: Vec::new(),
+                port,
+            })),
+        })),
+    };
+
+    let mut buf = Vec::with_capacity(proto_msg.encoded_len());
+    proto_msg.encode(&mut buf).unwrap();
+
+    TungMessage::Binary(buf)
+}
+
+/// Check if the protobuf message contains an HTTP response upgrade
+pub fn is_ws_upgrade_response(http_msg: ProtobufHttpMessage) -> bool {
+    match http_msg {
+        ProtobufHttpMessage::Request(_) => false,
+        ProtobufHttpMessage::Response(res) => {
+            res.status_code == 101 && res.headers.get("upgrade").unwrap().contains("websocket")
+        }
+    }
+}
+
+/// Create a WebSocket binary [`tungstenite`] message.
+pub fn create_ws_binary(socket_id: Vec<u8>, data: Vec<u8>) -> TungMessage {
+    let proto_msg = proto::Message {
+        protocol: Some(ProtobufProtocol::Ws(ProtobufWebSocket {
+            socket_id,
+            message: Some(ProtobufWsMessage::Binary(data)),
+        })),
+    };
+
+    let mut buf = Vec::with_capacity(proto_msg.encoded_len());
+    proto_msg.encode(&mut buf).unwrap();
+
+    TungMessage::Binary(buf)
+}
+
+/// Send a message on a WebSocket stream, wait for a message on the stream and return it.
+pub async fn send_ws_and_wait_next(
+    ws_stream: &mut WebSocketStream<TcpStream>,
+    data: TungMessage,
+) -> proto::Message {
+    ws_stream.send(data).await.expect("failed to send over ws");
+
+    // should receive an HTTP response with status code 101, stating that the connection upgrade
+    // was successful
+    let http_res = ws_stream
+        .next()
+        .await
+        .expect("ws already closed")
+        .expect("failed to receive from ws")
+        .into_data();
+
+    Message::decode(http_res.as_slice()).expect("failed to create protobuf message")
+}
+
+/// Utility struct to test a connection (HTTP or WebSocket) with the device
+#[derive(Debug)]
+pub struct TestConnections<M> {
+    /// Server used to mock the connections
+    pub mock_server: M,
+    listener: TcpListener,
+    connections_handle: JoinHandle<Result<(), Disconnected>>,
+}
+
+impl<M> TestConnections<M> {
+    /// Create a websocket connection and mock the bridge the device will connect to.
+    pub async fn mock_ws_server(&self) -> WebSocketStream<TcpStream> {
+        let (stream, _) = self
+            .listener
+            .accept()
+            .await
+            .expect("failed to accept connection");
+
+        tokio_tungstenite::accept_async(stream)
+            .await
+            .expect("failed to open a ws with the device")
+    }
+
+    /// Check if the connections manager correctly ended its execution.
+    pub async fn assert(self) {
+        let res = self.connections_handle.await.expect("task join failed");
+        assert!(res.is_ok(), "connection manager error {}", res.unwrap_err());
+    }
+}
+
+impl TestConnections<MockServer> {
+    /// Initialize the HTTP mock server.
+    pub async fn init() -> Self {
+        let mock_server = MockServer::start();
+
+        let (listener, port) = bind_port().await;
+        let url = format!("ws://localhost:{port}/remote-terminal?session_token=1234");
+
+        Self {
+            mock_server,
+            listener,
+            connections_handle: tokio::spawn(con_manager(url, false)),
+        }
+    }
+
+    /// Retrieve the mock endpoint
+    pub fn endpoint(&self) -> Mock {
+        // Create a mock on the server.
+        self.mock_server.mock(|when, then| {
+            when.method(GET)
+                .path("/remote-terminal")
+                .query_param("session_token", "abcd");
+            then.status(200)
+                .header("content-type", "text/html")
+                .body("just do it");
+        })
+    }
+}
+
+impl TestConnections<MockWebSocket> {
+    /// Initialize the WebSocket mock server.
+    pub async fn init() -> Self {
+        let mock_server = MockWebSocket::start().await;
+
+        let (listener, port) = bind_port().await;
+        let url = format!("ws://localhost:{port}/remote-terminal?session_token=1234");
+
+        Self {
+            mock_server,
+            listener,
+            connections_handle: tokio::spawn(con_manager(url, false)),
+        }
+    }
+
+    /// Mock the WebSocket stream between the device and an internal service (e.g., TTYD)
+    #[instrument(skip_all)]
+    pub async fn mock(&mut self, connecting_handle: JoinHandle<WebSocketStream<TcpStream>>) {
+        let ws_stream = connecting_handle.await.unwrap();
+        MockWebSocket::mock(ws_stream);
+        self.mock_server.0 = WsState::Connected;
+    }
+}
+
+/// WebSocket mock server
+#[derive(Debug)]
+pub struct MockWebSocket(WsState);
+
+#[derive(Debug)]
+enum WsState {
+    Pending {
+        listener: Option<TcpListener>,
+        port: u16,
+    },
+    Connected,
+}
+
+impl MockWebSocket {
+    /// Initialize the mock server.
+    pub async fn start() -> Self {
+        let (listener, port) = bind_port().await;
+        Self(WsState::Pending {
+            listener: Some(listener),
+            port,
+        })
+    }
+
+    /// Retrieve the [`TcpListener`] from a mock server in a Pending state.
+    pub fn device_listener(&mut self) -> Option<TcpListener> {
+        match &mut self.0 {
+            WsState::Pending { listener, .. } => listener.take(),
+            WsState::Connected => None,
+        }
+    }
+
+    /// Retrieve the port the mock server will listen to new websocket connections.
+    pub fn port(&self) -> Option<u16> {
+        match self.0 {
+            WsState::Pending { port, .. } => Some(port),
+            _ => None,
+        }
+    }
+
+    /// Check if the mock server established a WebSocket connection.
+    pub fn is_connected(&self) -> bool {
+        matches!(self.0, WsState::Connected)
+    }
+
+    /// Accept a WebSocket connection from a device request.
+    #[instrument(skip_all)]
+    pub fn open_ws_device(listener: TcpListener) -> JoinHandle<WebSocketStream<TcpStream>> {
+        tokio::spawn(async move {
+            debug!("creating stream at {listener:?}");
+
+            let (stream, _) = listener
+                .accept()
+                .await
+                .expect("failed to accept connection");
+
+            tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("failed to open a ws with the device")
+        })
+    }
+
+    /// Spawn the task responsible for mocking a service behavior once received a WebSocket message
+    /// from the device.
+    pub fn mock(ws_stream: WebSocketStream<TcpStream>) -> JoinHandle<()> {
+        tokio::spawn(Self::handle_ws(ws_stream))
+    }
+
+    async fn handle_ws(mut ws_stream: WebSocketStream<TcpStream>) {
+        // loop endlessly. Upon receiving a message, forward it back
+        while let Some(msg) = ws_stream.next().await {
+            let msg = msg.expect("failed to receive from ws");
+            // check what kind of frame is received
+            let msg_response = match msg {
+                TungMessage::Text(_) => todo!("handle text"),
+                // if binary, forward it
+                TungMessage::Binary(data) => {
+                    // TODO: check if some checks should be performed before reconstructing the same message
+                    TungMessage::Binary(data)
+                }
+                TungMessage::Ping(_) => todo!("handle ping"),
+                TungMessage::Pong(_) => todo!("handle pong"),
+                TungMessage::Close(_) => todo!("handle close"),
+                TungMessage::Frame(_) => unreachable!("should never be sent"),
+            };
+
+            ws_stream
+                .send(msg_response)
+                .await
+                .expect("failed to send over ws");
+        }
+    }
+}

--- a/edgehog-device-runtime-forwarder/tests/http_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/http_test.rs
@@ -3,172 +3,63 @@
 
 use edgehog_device_forwarder_proto::http::Message as HttpMessage;
 use edgehog_device_forwarder_proto::{
-    http::Request as HttpRequest, http::Response as HttpResponse, message::Protocol, Http,
+    http::Response as HttpResponse, message::Protocol, prost::Message, Http,
     Message as ProtoMessage,
 };
 use futures::{SinkExt, StreamExt};
-use httpmock::prelude::*;
-use httpmock::Mock;
-use std::future::Future;
-use tokio::net::{TcpListener, TcpStream};
-use tokio::task::JoinHandle;
-use tokio_tungstenite::{tungstenite::Message as TungMessage, WebSocketStream};
-use url::Url;
 
-use edgehog_device_forwarder_proto::prost::Message;
-use edgehog_device_runtime_forwarder::connections_manager::{ConnectionsManager, Disconnected};
 use uuid::Uuid;
 
-async fn bind_port() -> (TcpListener, u16) {
-    let listener = TcpListener::bind("localhost:0")
-        .await
-        .expect("failed to create a tcp listener");
-
-    let port = listener
-        .local_addr()
-        .expect("failed to retrieve local addr")
-        .port();
-
-    (listener, port)
-}
-
-async fn con_manager(url: Url) -> Result<(), Disconnected> {
-    let secure = false;
-    let mut con_manager = ConnectionsManager::connect(url, secure)
-        .await
-        .expect("failed to connect connections manager");
-    con_manager.handle_connections().await
-}
-
-fn create_http_req(url: &str, request_id: Vec<u8>) -> TungMessage {
-    let url = Url::parse(url).expect("failed to pars Url");
-    let proto_msg = ProtoMessage {
-        protocol: Some(Protocol::Http(Http {
-            request_id,
-            message: Some(HttpMessage::Request(HttpRequest {
-                path: url.path().trim_start_matches('/').to_string(),
-                method: http::Method::GET.to_string(),
-                query_string: url.query().unwrap_or_default().to_string(),
-                port: url.port().expect("nonexistent port").into(),
-                ..Default::default()
-            })),
-        })),
-    };
-
-    let mut buf = Vec::with_capacity(proto_msg.encoded_len());
-    proto_msg
-        .encode(&mut buf)
-        .expect("failed to encode protobuf");
-
-    TungMessage::Binary(buf)
-}
-
-struct TestConnections {
-    mock_server: MockServer,
-    listener: TcpListener,
-    connections_handle: JoinHandle<Result<(), Disconnected>>,
-}
-
-impl TestConnections {
-    async fn init() -> Self {
-        let mock_server = MockServer::start();
-
-        let (listener, port) = bind_port().await;
-        let url = format!("ws://localhost:{port}/remote-terminal?session_token=1234")
-            .parse()
-            .expect("failed to parse url");
-
-        Self {
-            mock_server,
-            listener,
-            connections_handle: tokio::spawn(con_manager(url)),
-        }
-    }
-
-    fn endpoint(&self) -> Mock {
-        // Create a mock on the server.
-        self.mock_server.mock(|when, then| {
-            when.method(GET)
-                .path("/remote-terminal")
-                .query_param("session_token", "abcd");
-            then.status(200)
-                .header("content-type", "text/html")
-                .body("just do it");
-        })
-    }
-
-    async fn mock_ws_server<F>(&self, f: impl FnOnce(WebSocketStream<TcpStream>) -> F)
-    where
-        F: Future,
-    {
-        let (stream, _) = self
-            .listener
-            .accept()
-            .await
-            .expect("failed to accept connection");
-
-        let ws_stream = tokio_tungstenite::accept_async(stream)
-            .await
-            .expect("failed to open a ws with the device");
-
-        f(ws_stream).await;
-    }
-
-    async fn assert<'a>(self) {
-        let res = self.connections_handle.await.expect("task join failed");
-        assert!(res.is_ok(), "connection manager error {}", res.unwrap_err());
-    }
-}
-
+#[cfg(feature = "_test-utils")]
 #[tokio::test]
 async fn test_connect() {
-    let test_connections = TestConnections::init().await;
+    use edgehog_device_runtime_forwarder::test_utils::{create_http_req, TestConnections};
+
+    let test_connections = TestConnections::<httpmock::MockServer>::init().await;
     let endpoint = test_connections.endpoint();
 
     let test_url = test_connections
         .mock_server
         .url("/remote-terminal?session_token=abcd");
 
-    test_connections
-        .mock_ws_server(|mut ws| async move {
-            let request_id = Uuid::new_v4().as_bytes().to_vec();
-            let http_req = create_http_req(&test_url, request_id);
+    let mut ws = test_connections.mock_ws_server().await;
 
-            ws.send(http_req.clone())
-                .await
-                .expect("failed to send over ws");
+    let request_id = Uuid::new_v4().as_bytes().to_vec();
+    let http_req = create_http_req(request_id, &test_url);
 
-            // send again another request with the same ID. This should cause an IdAlreadyUsed error
-            // which is internally handled (print in debug mode)
-            ws.send(http_req).await.expect("failed to send over ws");
+    ws.send(http_req.clone())
+        .await
+        .expect("failed to send over ws");
 
-            // the 1st request is correctly handled
-            let http_res = ws
-                .next()
-                .await
-                .expect("ws already closed")
-                .expect("failed to receive from ws")
-                .into_data();
+    // send again another request with the same ID. This should cause an IdAlreadyUsed error
+    // which is internally handled (print in debug mode)
+    ws.send(http_req).await.expect("failed to send over ws");
 
-            let proto_res = ProtoMessage::decode(http_res.as_slice())
-                .expect("failed to decode tung message into protobuf");
+    // the 1st request is correctly handled
+    let http_res = ws
+        .next()
+        .await
+        .expect("ws already closed")
+        .expect("failed to receive from ws")
+        .into_data();
 
-            assert!(matches!(
-                proto_res,
-                ProtoMessage {
-                    protocol: Some(Protocol::Http(Http {
-                        message: Some(HttpMessage::Response(HttpResponse {
-                            status_code: 200,
-                            ..
-                        })),
-                        ..
-                    })),
-                }
-            ));
+    let proto_res = ProtoMessage::decode(http_res.as_slice())
+        .expect("failed to decode tung message into protobuf");
 
-            ws.close(None).await.expect("failed to close ws");
-        })
-        .await;
+    assert!(matches!(
+        proto_res,
+        ProtoMessage {
+            protocol: Some(Protocol::Http(Http {
+                message: Some(HttpMessage::Response(HttpResponse {
+                    status_code: 200,
+                    ..
+                })),
+                ..
+            })),
+        }
+    ));
+
+    ws.close(None).await.expect("failed to close ws");
 
     endpoint.assert();
     test_connections.assert().await;

--- a/edgehog-device-runtime-forwarder/tests/http_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/http_test.rs
@@ -18,7 +18,7 @@ async fn test_connect() {
 
     let test_url = test_connections
         .mock_server
-        .url("/remote-terminal?session_token=abcd");
+        .url("/remote-terminal?session=abcd");
 
     let mut ws = test_connections.mock_ws_server().await;
 
@@ -69,14 +69,12 @@ async fn test_max_sizes() {
     use edgehog_device_runtime_forwarder::test_utils::{create_big_http_req, TestConnections};
 
     let test_connections = TestConnections::<httpmock::MockServer>::init().await;
-
-    let test_url = test_connections
-        .mock_server
-        .url("/remote-terminal?session_token=abcd");
-
     let mut ws = test_connections.mock_ws_server().await;
 
     let request_id = "3647edbb-6747-4827-a3ef-dbb6239e3326".as_bytes().to_vec();
+    let test_url = test_connections
+        .mock_server
+        .url("/remote-terminal?session=abcd");
     let http_req = create_big_http_req(request_id.clone(), &test_url);
 
     // sending a frame bigger than the maximum frame size will cause a connection reset error.

--- a/edgehog-device-runtime-forwarder/tests/http_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/http_test.rs
@@ -8,8 +8,6 @@ use edgehog_device_forwarder_proto::{
 };
 use futures::{SinkExt, StreamExt};
 
-use uuid::Uuid;
-
 #[cfg(feature = "_test-utils")]
 #[tokio::test]
 async fn test_connect() {
@@ -24,7 +22,7 @@ async fn test_connect() {
 
     let mut ws = test_connections.mock_ws_server().await;
 
-    let request_id = Uuid::new_v4().as_bytes().to_vec();
+    let request_id = "3647edbb-6747-4827-a3ef-dbb6239e3326".as_bytes().to_vec();
     let http_req = create_http_req(request_id, &test_url);
 
     ws.send(http_req.clone())
@@ -63,4 +61,25 @@ async fn test_connect() {
 
     endpoint.assert();
     test_connections.assert().await;
+}
+
+#[cfg(feature = "_test-utils")]
+#[tokio::test]
+async fn test_max_sizes() {
+    use edgehog_device_runtime_forwarder::test_utils::{create_big_http_req, TestConnections};
+
+    let test_connections = TestConnections::<httpmock::MockServer>::init().await;
+
+    let test_url = test_connections
+        .mock_server
+        .url("/remote-terminal?session_token=abcd");
+
+    let mut ws = test_connections.mock_ws_server().await;
+
+    let request_id = "3647edbb-6747-4827-a3ef-dbb6239e3326".as_bytes().to_vec();
+    let http_req = create_big_http_req(request_id.clone(), &test_url);
+
+    // sending a frame bigger than the maximum frame size will cause a connection reset error.
+    let res = ws.send(http_req.clone()).await;
+    assert!(res.is_err(), "expected error {res:?}");
 }

--- a/edgehog-device-runtime-forwarder/tests/ws_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/ws_test.rs
@@ -30,7 +30,8 @@ async fn test_internal_ws() {
         "ws://localhost:{}/remote-terminal?session=abcd",
         test_connections.mock_server.port().unwrap()
     );
-    let http_req = create_http_upgrade_req(request_id.clone(), &url);
+    let http_req = create_http_upgrade_req(request_id.clone(), &url)
+        .expect("failed to create http upgrade request");
 
     let protobuf_res = send_ws_and_wait_next(&mut ws_bridge, http_req).await;
 

--- a/edgehog-device-runtime-forwarder/tests/ws_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/ws_test.rs
@@ -9,10 +9,11 @@ use edgehog_device_forwarder_proto::{
 };
 use tokio_tungstenite::tungstenite::Message as TungMessage;
 
+use edgehog_device_runtime_forwarder::test_utils::create_ws_msg;
 #[cfg(feature = "_test-utils")]
 use edgehog_device_runtime_forwarder::test_utils::{
-    create_http_upgrade_req, create_ws_msg, is_ws_upgrade_response, send_ws_and_wait_next,
-    MockWebSocket, TestConnections,
+    create_http_upgrade_req, is_ws_upgrade_response, send_ws_and_wait_next, MockWebSocket,
+    TestConnections,
 };
 
 #[cfg(feature = "_test-utils")]
@@ -42,7 +43,7 @@ async fn test_internal_ws() {
     assert_eq!(request_id, socket_id);
     assert!(is_ws_upgrade_response(protobuf_http));
 
-    // retrieve the ID of the connection and try sending a websocket message
+    // retrieve the ID of the connection and try sending a WebSocket message
     test_connections.mock(connection_handle).await;
 
     let content = b"data".to_vec();

--- a/edgehog-device-runtime-forwarder/tests/ws_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/ws_test.rs
@@ -7,25 +7,24 @@ use edgehog_device_forwarder_proto::{
     message::Protocol as ProtobufProtocol, web_socket::Message as ProtobufWsMessage,
     WebSocket as ProtobufWebSocket,
 };
+use tokio_tungstenite::tungstenite::Message as TungMessage;
 
 #[cfg(feature = "_test-utils")]
 use edgehog_device_runtime_forwarder::test_utils::{
-    create_http_upgrade_req, create_ws_binary, is_ws_upgrade_response, send_ws_and_wait_next,
+    create_http_upgrade_req, create_ws_msg, is_ws_upgrade_response, send_ws_and_wait_next,
     MockWebSocket, TestConnections,
 };
 
 #[cfg(feature = "_test-utils")]
 #[tokio::test]
 async fn test_internal_ws() {
-    use uuid::Uuid;
-
     let mut test_connections = TestConnections::<MockWebSocket>::init().await;
 
     let mut ws_bridge = test_connections.mock_ws_server().await;
     let listener = test_connections.mock_server.device_listener().unwrap();
     let connection_handle = MockWebSocket::open_ws_device(listener);
 
-    let request_id = Uuid::new_v4().as_bytes().to_vec();
+    let request_id = "3647edbb-6747-4827-a3ef-dbb6239e3326".as_bytes().to_vec();
     let url = format!(
         "ws://localhost:{}/remote-terminal?session_token=abcd",
         test_connections.mock_server.port().unwrap()
@@ -46,17 +45,34 @@ async fn test_internal_ws() {
     // retrieve the ID of the connection and try sending a websocket message
     test_connections.mock(connection_handle).await;
 
-    let data = b"data".to_vec();
-    let ws_msg = create_ws_binary(socket_id.clone(), data.clone());
-
-    let protobuf_res = send_ws_and_wait_next(&mut ws_bridge, ws_msg).await;
+    let content = b"data".to_vec();
+    let data = TungMessage::Binary(content.clone());
+    let ws_binary_msg = create_ws_msg(socket_id.clone(), data);
+    let protobuf_res = send_ws_and_wait_next(&mut ws_bridge, ws_binary_msg).await;
 
     assert_eq!(
         protobuf_res,
         proto::Message {
             protocol: Some(ProtobufProtocol::Ws(ProtobufWebSocket {
-                message: Some(ProtobufWsMessage::Binary(data)),
-                socket_id
+                message: Some(ProtobufWsMessage::Binary(content)),
+                socket_id: socket_id.clone()
+            }))
+        }
+    );
+
+    // sending ping
+    let content = b"ping".to_vec();
+    let data = TungMessage::Ping(content.clone());
+    let ws_ping_msg = create_ws_msg(socket_id.clone(), data.clone());
+    let protobuf_res = send_ws_and_wait_next(&mut ws_bridge, ws_ping_msg).await;
+
+    // check that a pong is received
+    assert_eq!(
+        protobuf_res,
+        proto::Message {
+            protocol: Some(ProtobufProtocol::Ws(ProtobufWebSocket {
+                message: Some(ProtobufWsMessage::Pong(content)),
+                socket_id: socket_id.clone()
             }))
         }
     );

--- a/edgehog-device-runtime-forwarder/tests/ws_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/ws_test.rs
@@ -1,0 +1,63 @@
+// Copyright 2023 SECO Mind Srl
+// SPDX-License-Identifier: Apache-2.0
+
+use edgehog_device_forwarder_proto as proto;
+use edgehog_device_forwarder_proto::message::Protocol;
+use edgehog_device_forwarder_proto::{
+    message::Protocol as ProtobufProtocol, web_socket::Message as ProtobufWsMessage,
+    WebSocket as ProtobufWebSocket,
+};
+
+#[cfg(feature = "_test-utils")]
+use edgehog_device_runtime_forwarder::test_utils::{
+    create_http_upgrade_req, create_ws_binary, is_ws_upgrade_response, send_ws_and_wait_next,
+    MockWebSocket, TestConnections,
+};
+
+#[cfg(feature = "_test-utils")]
+#[tokio::test]
+async fn test_internal_ws() {
+    use uuid::Uuid;
+
+    let mut test_connections = TestConnections::<MockWebSocket>::init().await;
+
+    let mut ws_bridge = test_connections.mock_ws_server().await;
+    let listener = test_connections.mock_server.device_listener().unwrap();
+    let connection_handle = MockWebSocket::open_ws_device(listener);
+
+    let request_id = Uuid::new_v4().as_bytes().to_vec();
+    let url = format!(
+        "ws://localhost:{}/remote-terminal?session_token=abcd",
+        test_connections.mock_server.port().unwrap()
+    );
+    let http_req = create_http_upgrade_req(request_id.clone(), &url);
+
+    let protobuf_res = send_ws_and_wait_next(&mut ws_bridge, http_req).await;
+
+    let (socket_id, protobuf_http) = match protobuf_res.protocol.unwrap() {
+        Protocol::Http(http) => (http.request_id, http.message.unwrap()),
+        Protocol::Ws(_) => panic!("should be http upgrade response"),
+    };
+
+    // check if the response id is the same as the request one
+    assert_eq!(request_id, socket_id);
+    assert!(is_ws_upgrade_response(protobuf_http));
+
+    // retrieve the ID of the connection and try sending a websocket message
+    test_connections.mock(connection_handle).await;
+
+    let data = b"data".to_vec();
+    let ws_msg = create_ws_binary(socket_id.clone(), data.clone());
+
+    let protobuf_res = send_ws_and_wait_next(&mut ws_bridge, ws_msg).await;
+
+    assert_eq!(
+        protobuf_res,
+        proto::Message {
+            protocol: Some(ProtobufProtocol::Ws(ProtobufWebSocket {
+                message: Some(ProtobufWsMessage::Binary(data)),
+                socket_id
+            }))
+        }
+    );
+}

--- a/edgehog-device-runtime-forwarder/tests/ws_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/ws_test.rs
@@ -26,7 +26,7 @@ async fn test_internal_ws() {
 
     let request_id = "3647edbb-6747-4827-a3ef-dbb6239e3326".as_bytes().to_vec();
     let url = format!(
-        "ws://localhost:{}/remote-terminal?session_token=abcd",
+        "ws://localhost:{}/remote-terminal?session=abcd",
         test_connections.mock_server.port().unwrap()
     );
     let http_req = create_http_upgrade_req(request_id.clone(), &url);


### PR DESCRIPTION
We would like to establish one or more WebSocket connections on top of
an existing WebSocket channel between a device and a bridge. For
instance, this could be useful in the scenario where a remote user, who
has access to the bridge, wishes to open a remote terminal exposed by
the device on a specific port and make it accessible through a WebSocket
connection.  The implementation of this functionality is described as
follows:
- `edgehog-device-runtime-forwarder/src/messages.rs` has been extended
  to reflect the changes in the `proto.rs` file, which contains the
  [`Protobuf`](https://protobuf.dev/) definition of the data exchanged
  between the device and the bridge. Since this extension introduces the
  WebSocket message type, now `messages.rs` contains the necessary structs
  and `impl` blocks responsible for handling such messages.
- `edgehog-device-runtime-forwarder/src/connections_manager.rs` also
  handles the sending and receiving of WebSocket messages on an already
  established WebSocket connection between the device and the bridge
  (refer to the `handle_ws()` method). To establish a WebSocket
  connection, the bridge first sends a triplet of HTTP messages, with the
  third being an HTTP `upgrade` request to the WebSocket protocol. Once
  this request is received, the device creates an internal WebSocket
  connection using [`TTYD`](https://github.com/tsl0922/ttyd), a tool used
  for sharing a remote terminal over a WebSocket interface. To simplify
  the connections' collection stored within the `ConnectionsManager`
  struct, both the HTTP and WebSocket connections are stored in the same
  collection (avoiding the problem of managing two separate collections
  for each type of connection). To this extent, the WebSocket connection
  is given the same ID as the corresponding HTTP upgrade request.
- `edgehog-device-runtime-forwarder/src/connection.rs` has been split into
  submodules, containing now two builder traits: `TransportBuilder` and 
  `Transport`. These traits (declared in `mod.rs`) define the `build()` and `next()` 
  methods, respectively, which are necessary to construct and handle each 
  connection. Specifically, two builders that implement the `TransportBuilder` 
  trait have been defined to create an HTTP and a WebSocket connection, 
  respectively implemented in the `connection/http.rs` and `connection/websocket.rs`. 
  These builders are used when spawning the Tokio task responsible for handling
  a single `Connection`. The `Connection` is now a struct that is generic
  on a type that implements the `Transport` trait. This is why the `Http`
  and `WebSocket` structs both implement this trait. The `Http` struct
  sends an HTTP request and waits for a response, while the `WebSocket`
  struct continuously sends and receives data to/from TTYD.