### PR TITLE
refactor(path): use path instead of string

### DIFF
--- a/e2e-test/src/main.rs
+++ b/e2e-test/src/main.rs
@@ -22,6 +22,7 @@ use astarte_device_sdk::types::AstarteType;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::panic;
+use std::path::PathBuf;
 
 use edgehog_device_runtime::data::astarte_device_sdk_lib::{
     astarte_map_options, AstarteDeviceSdkConfigOptions, AstarteDeviceSdkLib,
@@ -62,9 +63,9 @@ async fn main() -> Result<(), edgehog_device_runtime::error::DeviceManagerError>
             pairing_url: pairing_url.to_string(),
             pairing_token: None,
         }),
-        interfaces_directory: "./edgehog/astarte-interfaces".to_string(),
-        store_directory: "".to_string(),
-        download_directory: "".to_string(),
+        interfaces_directory: "./edgehog/astarte-interfaces".into(),
+        store_directory: PathBuf::new(),
+        download_directory: PathBuf::new(),
         astarte_ignore_ssl: Some(false),
         telemetry_config: Some(vec![]),
         astarte_message_hub: None,

--- a/src/data/astarte_device_sdk_lib.rs
+++ b/src/data/astarte_device_sdk_lib.rs
@@ -100,7 +100,7 @@ pub async fn astarte_map_options(
     let credentials_secret: String = get_credentials_secret(
         &device_id,
         astarte_device_sdk_options,
-        FileStateRepository::new(store_directory, format!("credentials_{}.json", device_id)),
+        FileStateRepository::new(&store_directory, format!("credentials_{}.json", device_id)),
     )
     .await?;
 
@@ -115,7 +115,14 @@ pub async fn astarte_map_options(
         sdk_options = sdk_options.ignore_ssl_errors();
     }
 
-    Ok(sdk_options.interface_directory(&opts.interfaces_directory)?)
+    let interfaces_dir = opts
+        .interfaces_directory
+        .to_str()
+        .ok_or_else(|| AstarteOptionsError::ConfigError("Non utf-8 interface path".to_string()))?;
+
+    sdk_options
+        .interface_directory(interfaces_dir)
+        .map_err(Into::into)
 }
 
 async fn get_device_id(opt_device_id: Option<String>) -> Result<String, DeviceManagerError> {
@@ -179,6 +186,8 @@ async fn get_credentials_secret_from_registration(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use crate::data::astarte_device_sdk_lib::{
         get_credentials_secret, get_credentials_secret_from_registration, get_device_id,
         AstarteDeviceSdkConfigOptions,
@@ -207,9 +216,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
@@ -239,9 +248,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
@@ -273,9 +282,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
@@ -307,9 +316,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
@@ -334,9 +343,9 @@ mod tests {
                 pairing_url: "".to_string(),
                 pairing_token: None,
             }),
-            interfaces_directory: "./".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
             astarte_message_hub: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use astarte_device_sdk::types::AstarteType;
@@ -60,9 +61,9 @@ pub struct DeviceManagerOptions {
     pub astarte_library: AstarteLibrary,
     pub astarte_device_sdk: Option<data::astarte_device_sdk_lib::AstarteDeviceSdkConfigOptions>,
     pub astarte_message_hub: Option<data::astarte_message_hub_node::AstarteMessageHubOptions>,
-    pub interfaces_directory: String,
-    pub store_directory: String,
-    pub download_directory: String,
+    pub interfaces_directory: PathBuf,
+    pub store_directory: PathBuf,
+    pub download_directory: PathBuf,
     pub astarte_ignore_ssl: Option<bool>,
     pub telemetry_config: Option<Vec<telemetry::TelemetryInterfaceConfig>>,
 }
@@ -369,6 +370,8 @@ pub mod e2e_test {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use astarte_device_sdk::types::AstarteType;
     use astarte_device_sdk::{AstarteAggregate, AstarteDeviceDataEvent};
     use async_trait::async_trait;
@@ -436,9 +439,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "./".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
@@ -462,9 +465,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };
@@ -493,9 +496,9 @@ mod tests {
                 pairing_token: None,
             }),
             astarte_message_hub: None,
-            interfaces_directory: "./".to_string(),
-            store_directory: "".to_string(),
-            download_directory: "".to_string(),
+            interfaces_directory: PathBuf::new(),
+            store_directory: PathBuf::new(),
+            download_directory: PathBuf::new(),
             astarte_ignore_ssl: Some(false),
             telemetry_config: Some(vec![]),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,18 +97,18 @@ async fn main() -> Result<(), DeviceManagerError> {
         AstarteLibrary::AstarteMessageHub => {
             use edgehog_device_runtime::data::astarte_message_hub_node::AstarteMessageHubNode;
 
-            let interfaces_directory = options.interfaces_directory.clone();
             let astarte_message_hub_options = options
                 .astarte_message_hub
                 .clone()
                 .expect("Unable to find MessageHub options");
 
-            let mut dm = edgehog_device_runtime::DeviceManager::new(
-                options,
-                AstarteMessageHubNode::new(astarte_message_hub_options, interfaces_directory)
-                    .await?,
+            let publisher = AstarteMessageHubNode::new(
+                astarte_message_hub_options,
+                &options.interfaces_directory,
             )
             .await?;
+
+            let mut dm = edgehog_device_runtime::DeviceManager::new(options, publisher).await?;
 
             dm.init().await?;
 

--- a/src/ota/ota_handler.rs
+++ b/src/ota/ota_handler.rs
@@ -81,8 +81,7 @@ impl OtaHandler {
         let (sender, receiver) = mpsc::channel(8);
         let system_update = OTARauc::new().await?;
 
-        let state_repository =
-            FileStateRepository::new(opts.store_directory.clone(), "state.json".to_owned());
+        let state_repository = FileStateRepository::new(&opts.store_directory, "state.json");
 
         let ota =
             Ota::<OTARauc, FileStateRepository>::new(opts, system_update, state_repository).await?;


### PR DESCRIPTION
Use the `Path{Buf}` struct instead of strings to simplify the code.