### PR TITLE
chore(deps): update major version of the deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -358,7 +358,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.48.0",
 ]
 
@@ -385,7 +385,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -488,6 +488,33 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
 
 [[package]]
 name = "axum"
@@ -605,6 +632,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.76",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -685,7 +735,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-named-pipe",
  "hyper-util",
- "hyperlocal-next",
+ "hyperlocal",
  "log",
  "pin-project-lite",
  "serde",
@@ -703,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.44.0-rc.2"
+version = "1.45.0-rc.26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
 dependencies = [
  "serde",
  "serde_repr",
@@ -764,7 +814,18 @@ version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -792,6 +853,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -833,6 +905,15 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1084,6 +1165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "e2e-test"
 version = "0.1.0"
 dependencies = [
@@ -1148,7 +1235,6 @@ dependencies = [
  "httpmock",
  "log",
  "mockall",
- "pbjson-types",
  "procfs",
  "reqwest",
  "rustc_version_runtime",
@@ -1196,12 +1282,13 @@ dependencies = [
  "backoff",
  "displaydoc",
  "edgehog-device-forwarder-proto",
+ "env_logger",
  "futures",
  "hex",
  "http 1.1.0",
  "httpmock",
  "reqwest",
- "rustls 0.22.4",
+ "rustls 0.23.12",
  "rustls-native-certs",
  "rustls-pemfile",
  "thiserror",
@@ -1491,6 +1578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1752,12 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -1957,6 +2056,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2046,10 +2146,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlocal-next"
-version = "0.9.0"
+name = "hyperlocal"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
@@ -2181,6 +2281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "led-manager-service"
 version = "0.1.0"
 dependencies = [
@@ -2257,6 +2372,16 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libm"
@@ -2420,15 +2545,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.12.1"
+name = "mirai-annotations"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -2436,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -2869,7 +2999,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2971,7 +3101,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix 0.38.34",
+ "rustix 0.38.35",
 ]
 
 [[package]]
@@ -3048,7 +3178,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.12",
  "socket2 0.5.7",
  "thiserror",
@@ -3065,7 +3195,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.12",
  "slab",
  "thiserror",
@@ -3376,15 +3506,21 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -3415,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3446,6 +3582,8 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3485,10 +3623,11 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4080,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4090,7 +4229,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -4154,7 +4293,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.59.0",
 ]
 
@@ -4356,17 +4495,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.22.4",
+ "rustls 0.23.12",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tungstenite",
 ]
 
@@ -4527,9 +4666,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
 dependencies = [
  "byteorder",
  "bytes",
@@ -4538,7 +4677,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.22.4",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "sha1",
  "thiserror",
@@ -4554,9 +4693,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "udev"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50051c6e22be28ee6f217d50014f3bc29e81c20dc66ff7ca0d5c5226e1dcc5a1"
+checksum = "8ba005bcd5b1158ae3cd815905990e8b6ee4ba9ee7adbab6d7b58d389ad09c93"
 dependencies = [
  "io-lifetimes",
  "libc",
@@ -4828,6 +4967,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.35",
+]
+
+[[package]]
 name = "whoami"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,6 +5028,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ zbus = { workspace = true, default-features = false, features = ["tokio"] }
 astarte-message-hub-proto = { workspace = true }
 httpmock = { workspace = true }
 mockall = { workspace = true }
-pbjson-types = { workspace = true }
 tempdir = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-stream = { workspace = true, features = ["net"] }
@@ -70,50 +69,48 @@ tokio-stream = { workspace = true, features = ["net"] }
 message-hub = ["astarte-device-sdk/message-hub"]
 systemd = ["dep:systemd"]
 forwarder = ["dep:edgehog-forwarder"]
-e2e_test = []
 
 [workspace.dependencies]
 astarte-device-sdk = "0.8.3"
 astarte-message-hub-proto = "0.6.2"
-async-trait = "0.1.77"
+async-trait = "0.1.81"
 backoff = "0.4.0"
-base64 = "0.22.0"
-bollard = "0.16.1"
-bytes = "1.5.0"
+base64 = "0.22.1"
+bollard = "0.17.1"
+bytes = "1.7.1"
 clap = "=4.4.18"
 displaydoc = "0.2.5"
 edgehog-device-forwarder-proto = "0.1.0"
 edgehog-forwarder = { package = "edgehog-device-runtime-forwarder", path = "./edgehog-device-runtime-forwarder", version = "=0.8.1" }
-env_logger = "0.11.3"
+env_logger = "0.11.5"
 futures = "0.3.30"
 hex = "0.4.3"
 http = "1.1.0"
 httpmock = "0.7"
-hyper = "1.2.0"
-log = "0.4.20"
-mockall = "0.12.1"
-pbjson-types = "0.6"
-petgraph = "0.6.4"
+hyper = "1.4.1"
+log = "0.4.22"
+mockall = "0.13.0"
+petgraph = "0.6.5"
 procfs = "0.16.0"
-reqwest = "0.12.0"
+reqwest = "0.12.7"
 rustc_version_runtime = "0.3.0"
-rustls = "0.22.4"
-rustls-native-certs = "0.7.0"
-rustls-pemfile = "2.1.1"
-serde = "1.0.195"
-serde_json = "1.0.111"
-sysinfo = "0.29.11"
+rustls = "0.23.12"
+rustls-native-certs = "0.7.2"
+rustls-pemfile = "2.1.3"
+serde = "1.0.209"
+serde_json = "1.0.127"
+sysinfo = "0.30.13"
 systemd = "0.10.0"
 tempdir = "0.3.7"
-thiserror = "1.0.58"
-tokio = "1.35.1"
+thiserror = "1.0.63"
+tokio = "1.39.3"
 tokio-stream = "0.1.15"
-tokio-tungstenite = "0.21.0"
+tokio-tungstenite = "0.23.1"
 tokio-util = "0.7.11"
-toml = "0.8.2"
+toml = "0.8.19"
 tracing = "0.1.40"
-udev = "0.8.0"
-url = "2.4.1"
-uuid = "1.6.1"
+udev = "0.9.0"
+url = "2.5.2"
+uuid = "1.10.0"
 wifiscanner = "0.5.1"
-zbus = { version = "3.14.1", default-features = false }
+zbus = { version = "3.15.2", default-features = false }

--- a/e2e-test/Cargo.toml
+++ b/e2e-test/Cargo.toml
@@ -1,6 +1,6 @@
-# This file is part of Hedgehog.
+# This file is part of Edgehog.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 astarte-device-sdk = { workspace = true, features = ["derive"] }
-edgehog-device-runtime = { path = "..", features = ["e2e_test"] }
+edgehog-device-runtime = { path = ".." }
 env_logger = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
@@ -35,5 +35,4 @@ tempdir = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-# NOTE: needed to build with --all-features
 message-hub = ["edgehog-device-runtime/message-hub"]

--- a/edgehog-device-runtime-forwarder/Cargo.toml
+++ b/edgehog-device-runtime-forwarder/Cargo.toml
@@ -26,11 +26,12 @@ rustls-native-certs = { workspace = true }
 rustls-pemfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots", "url"] }
 tracing = { workspace = true, features = ["log"] }
 url = { workspace = true }
 
 [dev-dependencies]
+env_logger = { workspace = true }
 httpmock = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/edgehog-device-runtime-forwarder/tests/ws_test.rs
+++ b/edgehog-device-runtime-forwarder/tests/ws_test.rs
@@ -19,9 +19,14 @@ use edgehog_device_runtime_forwarder::test_utils::{
 #[cfg(feature = "_test-utils")]
 #[tokio::test]
 async fn test_internal_ws() {
+    env_logger::builder().is_test(true).init();
+
+    // Mock server for ttyd
     let mut test_connections = TestConnections::<MockWebSocket>::init().await;
 
+    // Edgehog
     let mut ws_bridge = test_connections.mock_ws_server().await;
+    // Device listener (waiting for Edgehog -> Device)
     let listener = test_connections.mock_server.device_listener().unwrap();
     let connection_handle = MockWebSocket::open_ws_device(listener);
 

--- a/src/data/astarte_message_hub_node.rs
+++ b/src/data/astarte_message_hub_node.rs
@@ -92,10 +92,13 @@ impl AstarteMessageHubOptions {
 mod tests {
     use astarte_device_sdk::types::AstarteType;
     use astarte_device_sdk::AstarteAggregate;
-    use astarte_message_hub_proto::astarte_message::Payload;
-    use astarte_message_hub_proto::message_hub_server::{MessageHub, MessageHubServer};
-    use astarte_message_hub_proto::tonic::{Code, Request, Response, Status};
-    use astarte_message_hub_proto::AstarteMessage;
+    use astarte_message_hub_proto::{
+        astarte_message::Payload,
+        message_hub_server::{MessageHub, MessageHubServer},
+        pbjson_types::Empty,
+        tonic::{Code, Request, Response, Status},
+        AstarteMessage,
+    };
     use async_trait::async_trait;
     use std::net::{Ipv6Addr, SocketAddr};
     use tokio::sync::oneshot::Sender;
@@ -117,11 +120,11 @@ mod tests {
             async fn send(
                 &self,
                 request: Request<astarte_message_hub_proto::AstarteMessage>,
-            ) -> Result<Response<pbjson_types::Empty>, Status> ;
+            ) -> Result<Response<astarte_message_hub_proto::pbjson_types::Empty>, Status> ;
             async fn detach(
                 &self,
                 request: Request<astarte_message_hub_proto::Node>,
-            ) -> Result<Response<pbjson_types::Empty>, Status> ;
+            ) -> Result<Response<astarte_message_hub_proto::pbjson_types::Empty>, Status> ;
         }
     }
 
@@ -288,7 +291,7 @@ mod tests {
 
         msg_hub
             .expect_send()
-            .returning(|_| Ok(Response::new(pbjson_types::Empty {})));
+            .returning(|_| Ok(Response::new(Empty {})));
 
         let (server_handle, drop_sender, port) = run_local_server(msg_hub).await;
 
@@ -389,7 +392,7 @@ mod tests {
 
         msg_hub
             .expect_send()
-            .returning(|_| Ok(Response::new(pbjson_types::Empty {})));
+            .returning(|_| Ok(Response::new(Empty {})));
 
         let (server_handle, drop_sender, port) = run_local_server(msg_hub).await;
 

--- a/src/telemetry/storage_usage.rs
+++ b/src/telemetry/storage_usage.rs
@@ -21,7 +21,7 @@
 use astarte_device_sdk::{astarte_aggregate, AstarteAggregate};
 use log::{error, warn};
 use std::collections::HashMap;
-use sysinfo::{DiskExt, System, SystemExt};
+use sysinfo::Disks;
 
 #[derive(Debug, AstarteAggregate)]
 #[astarte_aggregate(rename_all = "camelCase")]
@@ -33,10 +33,10 @@ pub struct DiskUsage {
 /// get structured data for `io.edgehog.devicemanager.StorageUsage` interface
 /// /dev/ is excluded from the device names since it is common for all devices
 pub fn get_storage_usage() -> HashMap<String, DiskUsage> {
-    let mut sys = System::new_all();
-    sys.refresh_disks();
+    let disks = Disks::new_with_refreshed_list();
 
-    sys.disks()
+    disks
+        .list()
         .iter()
         .filter_map(|disk| {
             let Some(name) = disk.name().to_str() else {


### PR DESCRIPTION
Update to latest version. Fix a new error in the forwarder test which requires the Sec-WebSocket-Protocol headers to be present in the mock server response. Remove unused features for the runtime e2e-test.