### PR TITLE
fix(clippy): solve some warnings

### DIFF
--- a/src/ota/ota_handler_test.rs
+++ b/src/ota/ota_handler_test.rs
@@ -1287,7 +1287,7 @@ async fn ensure_pending_ota_is_done_ota_success() {
         .expect_send_object()
         .withf(move |_: &str, _: &str, ota_event: &OtaEvent| {
             ota_event.status.eq("Success")
-                && ota_event.statusCode.eq("")
+                && ota_event.statusCode.is_empty()
                 && ota_event.statusProgress == 0
                 && ota_event.requestUUID == uuid.to_string()
         })

--- a/src/ota/rauc.rs
+++ b/src/ota/rauc.rs
@@ -298,7 +298,7 @@ where
     }
 }
 
-impl<'a, S> Stream for DeployStream<'a, S>
+impl<S> Stream for DeployStream<'_, S>
 where
     S: Stream<Item = Result<(i32, String), DeviceManagerError>> + Unpin,
 {
@@ -331,7 +331,7 @@ where
     }
 }
 
-impl<'a, S> FusedStream for DeployStream<'a, S>
+impl<S> FusedStream for DeployStream<'_, S>
 where
     S: Stream<Item = Result<(i32, String), DeviceManagerError>> + Unpin,
 {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -68,7 +68,7 @@ pub struct TelemetryInterfaceConfig<'a> {
     pub period: Option<u64>,
 }
 
-impl<'a> TelemetryInterfaceConfig<'a> {
+impl TelemetryInterfaceConfig<'_> {
     fn period_duration(&self) -> Option<Duration> {
         self.period.map(Duration::from_secs)
     }


### PR DESCRIPTION
Elide lifetimes when possible and use is_empty instead of `.eq("")`