### PR TITLE
feat(containers): add stop for the deployment

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -27,7 +27,7 @@ SPDX-FileCopyrightText = "2022-2024 SECO Mind Srl"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
-path = ["e2e-test-containers/assets/data.json"]
+path = ["e2e-test-containers/assets/*.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 SECO Mind Srl"
 SPDX-License-Identifier = "CC0-1.0"

--- a/e2e-test-containers/assets/stop.json
+++ b/e2e-test-containers/assets/stop.json
@@ -1,0 +1,9 @@
+{
+  "events": [
+    {
+      "interface": "io.edgehog.devicemanager.apps.DeploymentCommand",
+      "path": "/6a9b6d3c-4894-4fd0-af1d-44b326282c19/command",
+      "data": "stop"
+    }
+  ]
+}

--- a/e2e-test-containers/src/receive.rs
+++ b/e2e-test-containers/src/receive.rs
@@ -70,7 +70,11 @@ where
                             .start(&Id::new(ResourceType::Deployment, release_id))
                             .await?;
                     }
-                    "stop" => unimplemented!(),
+                    "stop" => {
+                        service
+                            .stop(&Id::new(ResourceType::Deployment, release_id))
+                            .await?;
+                    }
                     _ => {
                         bail!("unrecognize ApplicationCommand {cmd}");
                     }

--- a/edgehog-device-runtime-containers/src/docker/container.rs
+++ b/edgehog-device-runtime-containers/src/docker/container.rs
@@ -357,6 +357,14 @@ where
         match res {
             Ok(()) => Ok(Some(())),
             Err(BollardError::DockerResponseServerError {
+                status_code: 304,
+                message,
+            }) => {
+                debug!("container already stopped: {message}");
+
+                Ok(Some(()))
+            }
+            Err(BollardError::DockerResponseServerError {
                 status_code: 404,
                 message,
             }) => {

--- a/edgehog-device-runtime-containers/src/properties/container.rs
+++ b/edgehog-device-runtime-containers/src/properties/container.rs
@@ -71,9 +71,9 @@ pub(crate) enum ContainerStatus {
     /// The [`Container`](crate::container::Container) has been created.
     Created,
     /// The [`Container`](crate::container::Container) is running.
-    _Running,
+    Running,
     /// The [`Container`](crate::container::Container) was stopped or crashed.
-    _Stopped,
+    Stopped,
 }
 
 impl Display for ContainerStatus {
@@ -81,8 +81,8 @@ impl Display for ContainerStatus {
         match self {
             ContainerStatus::Received => write!(f, "Received"),
             ContainerStatus::Created => write!(f, "Created"),
-            ContainerStatus::_Running => write!(f, "Running"),
-            ContainerStatus::_Stopped => write!(f, "Stopped"),
+            ContainerStatus::Running => write!(f, "Running"),
+            ContainerStatus::Stopped => write!(f, "Stopped"),
         }
     }
 }
@@ -111,8 +111,8 @@ mod tests {
         let statuses = [
             ContainerStatus::Received,
             ContainerStatus::Created,
-            ContainerStatus::_Running,
-            ContainerStatus::_Stopped,
+            ContainerStatus::Running,
+            ContainerStatus::Stopped,
         ];
         for status in statuses {
             let container = AvailableContainers { id: &id, status };

--- a/edgehog-device-runtime-containers/src/service/collection.rs
+++ b/edgehog-device-runtime-containers/src/service/collection.rs
@@ -68,8 +68,15 @@ impl NodeGraph {
             .filter_map(|dep| self.get_id(dep))
     }
 
+    /// Get the ids of a node depending on the one provided
+    pub(crate) fn dependent(&self, idx: NodeIndex) -> impl Iterator<Item = &Id> {
+        self.relations
+            .neighbors_directed(idx, Direction::Outgoing)
+            .filter_map(|dep| self.get_id(dep))
+    }
+
     /// Get a reference to a node
-    pub(crate) fn node(&mut self, id: &Id) -> Option<&Node> {
+    pub(crate) fn node(&self, id: &Id) -> Option<&Node> {
         self.nodes.get(id).filter(|node| !node.state().is_missing())
     }
     /// Get a mutable reference to anode

--- a/edgehog-device-runtime-containers/src/service/mod.rs
+++ b/edgehog-device-runtime-containers/src/service/mod.rs
@@ -453,6 +453,83 @@ where
 
         Ok(())
     }
+
+    /// Will stop an application
+    #[instrument(skip(self))]
+    pub async fn stop(&mut self, id: &Id) -> Result<()>
+    where
+        D: Client + Sync + 'static,
+    {
+        debug!("stopping {id}");
+
+        let node = self
+            .nodes
+            .node(id)
+            .ok_or_else(|| ServiceError::MissingNode(*id))?;
+
+        if node.is_deployment() {
+            DeploymentEvent::new(EventStatus::Stopping, "")
+                .send(id.uuid(), &self.device)
+                .await?;
+        } else {
+            warn!("stopping a {node:?} and not a deployment");
+        }
+
+        let idx = node.idx;
+
+        let res = self.stop_node(idx).await;
+
+        if let Err(err) = &res {
+            DeploymentEvent::new(EventStatus::Error, err.to_string())
+                .send(id.uuid(), &self.device)
+                .await?;
+        }
+
+        res
+    }
+
+    async fn stop_node(&mut self, start_idx: NodeIndex) -> Result<()>
+    where
+        D: Client + Sync + 'static,
+    {
+        let mut space = petgraph::visit::DfsPostOrder::new(self.nodes.relations(), start_idx);
+
+        let mut relations = Vec::new();
+        while let Some(idx) = space.next(self.nodes.relations()) {
+            if idx == start_idx {
+                // The deployment stopped should be the last event.
+                debug!("skipping the starting node");
+                continue;
+            }
+
+            let id = *self
+                .nodes
+                .get_id(idx)
+                .ok_or(ServiceError::MissingRelation)?;
+
+            relations.push(id);
+        }
+
+        let start_id = *self
+            .nodes
+            .get_id(start_idx)
+            .ok_or(ServiceError::MissingRelation)?;
+        // Push the deployment last
+        relations.push(start_id);
+
+        for id in relations {
+            let node = self
+                .nodes
+                .node_mut(&id)
+                .ok_or_else(|| ServiceError::MissingNode(id))?;
+
+            node.stop(&self.device, &self.client).await?;
+
+            self.store.store(&self.nodes).await?;
+        }
+
+        Ok(())
+    }
 }
 
 /// Id of the nodes in the Service graph

--- a/edgehog-device-runtime-containers/src/service/node.rs
+++ b/edgehog-device-runtime-containers/src/service/node.rs
@@ -105,6 +105,11 @@ impl Node {
                 | State::Up(NodeType::Deployment)
         )
     }
+
+    /// Check if the state of the node is [`State::Up`]
+    pub(crate) fn is_up(&self) -> bool {
+        matches!(self.state, State::Up(_))
+    }
 }
 
 #[cfg(test)]

--- a/edgehog-device-runtime-containers/src/service/node.rs
+++ b/edgehog-device-runtime-containers/src/service/node.rs
@@ -73,6 +73,13 @@ impl Node {
         self.state.up(&self.id, device, client).await
     }
 
+    pub(crate) async fn stop<D>(&mut self, device: &D, client: &Docker) -> Result<()>
+    where
+        D: Client + Sync + 'static,
+    {
+        self.state.stop(&self.id, device, client).await
+    }
+
     pub(crate) fn id(&self) -> &Id {
         &self.id
     }


### PR DESCRIPTION
Implement the stop for the deployment that will stop all the container
in the deployment. It will skip containers used in other deployments.
