### PR TITLE
fix(container): order container to delete 

### DIFF
--- a/e2e-test-containers/assets/data.json
+++ b/e2e-test-containers/assets/data.json
@@ -22,8 +22,8 @@
         "restartPolicy": "",
         "env": [],
         "binds": [],
-        "networks": [],
         "portBindings": ["9000:80"],
+        "networkMode": "bridge",
         "privileged": false
       }
     },

--- a/e2e-test-containers/assets/update.json
+++ b/e2e-test-containers/assets/update.json
@@ -22,8 +22,8 @@
         "restartPolicy": "",
         "env": [],
         "binds": [],
-        "networks": [],
         "portBindings": ["9000:80"],
+        "networkMode": "bridge",
         "privileged": false
       }
     },

--- a/edgehog-device-runtime-containers/src/docker/mod.rs
+++ b/edgehog-device-runtime-containers/src/docker/mod.rs
@@ -23,7 +23,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::client::*;
+pub(crate) use crate::client::*;
 use crate::error::DockerError;
 
 pub(crate) mod container;

--- a/edgehog-device-runtime-containers/src/events.rs
+++ b/edgehog-device-runtime-containers/src/events.rs
@@ -31,8 +31,8 @@ const INTERFACE: &str = "io.edgehog.devicemanager.apps.DeploymentEvent";
 /// Deployment status event
 #[derive(Debug, Clone, AstarteAggregate)]
 pub(crate) struct DeploymentEvent {
-    status: EventStatus,
-    message: String,
+    pub(crate) status: EventStatus,
+    pub(crate) message: String,
 }
 
 impl DeploymentEvent {

--- a/edgehog-device-runtime-containers/src/requests/container.rs
+++ b/edgehog-device-runtime-containers/src/requests/container.rs
@@ -211,12 +211,17 @@ pub(crate) mod tests {
 
     use super::*;
 
-    pub fn create_container_request_event(id: impl Display, image_id: &str) -> DeviceEvent {
+    pub fn create_container_request_event(
+        id: impl Display,
+        image_id: &str,
+        image: &str,
+        network_ids: &[&str],
+    ) -> DeviceEvent {
         let fields = [
             ("id", AstarteType::String(id.to_string())),
             ("imageId", AstarteType::String(image_id.to_string())),
             ("volumeIds", AstarteType::StringArray(vec![])),
-            ("image", AstarteType::String("image".to_string())),
+            ("image", AstarteType::String(image.to_string())),
             ("hostname", AstarteType::String("hostname".to_string())),
             ("restartPolicy", AstarteType::String("no".to_string())),
             ("env", AstarteType::StringArray(vec!["env".to_string()])),
@@ -224,7 +229,7 @@ pub(crate) mod tests {
             ("networkMode", AstarteType::String("bridge".to_string())),
             (
                 "networkIds",
-                AstarteType::StringArray(vec!["9808bbd5-2e81-4f99-83e7-7cc60623a196".to_string()]),
+                AstarteType::StringArray(network_ids.iter().map(|s| s.to_string()).collect()),
             ),
             (
                 "portBindings",
@@ -245,7 +250,12 @@ pub(crate) mod tests {
 
     #[test]
     fn create_container_request() {
-        let event = create_container_request_event("id", "image_id");
+        let event = create_container_request_event(
+            "id",
+            "image_id",
+            "image",
+            &["9808bbd5-2e81-4f99-83e7-7cc60623a196"],
+        );
 
         let request = CreateContainer::from_event(event).unwrap();
 


### PR DESCRIPTION
Revert the order of the resource visited so they can be deleted
correctly. We need to delete the containers before the images, etc.