### PR TITLE
feat(container): use uuid instead of strings

### DIFF
--- a/edgehog-device-runtime-containers/src/docker/container.rs
+++ b/edgehog-device-runtime-containers/src/docker/container.rs
@@ -487,10 +487,10 @@ where
 #[derive(Debug, Clone, Default)]
 pub struct PortBindingMap<S>(pub HashMap<String, Vec<Binding<S>>>);
 
-impl TryFrom<Vec<String>> for PortBindingMap<String> {
+impl TryFrom<&[String]> for PortBindingMap<String> {
     type Error = BindingError;
 
-    fn try_from(value: Vec<String>) -> Result<Self, Self::Error> {
+    fn try_from(value: &[String]) -> Result<Self, Self::Error> {
         value
             .iter()
             .try_fold(

--- a/edgehog-device-runtime-containers/src/requests/image.rs
+++ b/edgehog-device-runtime-containers/src/requests/image.rs
@@ -22,6 +22,8 @@ use astarte_device_sdk::FromEvent;
 
 use crate::image::Image;
 
+use super::ReqUuid;
+
 /// Request to pull a Docker Image.
 #[derive(Debug, Clone, FromEvent, PartialEq, Eq, PartialOrd, Ord)]
 #[from_event(
@@ -30,7 +32,7 @@ use crate::image::Image;
     rename_all = "camelCase"
 )]
 pub struct CreateImage {
-    pub(crate) id: String,
+    pub(crate) id: ReqUuid,
     pub(crate) reference: String,
     pub(crate) registry_auth: String,
 }
@@ -56,8 +58,21 @@ pub(crate) mod tests {
     use std::fmt::Display;
 
     use astarte_device_sdk::{DeviceEvent, Value};
+    use uuid::Uuid;
 
     use super::*;
+
+    pub fn mock_image_req(
+        id: Uuid,
+        reference: impl Into<String>,
+        registry_auth: impl Into<String>,
+    ) -> CreateImage {
+        CreateImage {
+            id: ReqUuid(id),
+            reference: reference.into(),
+            registry_auth: registry_auth.into(),
+        }
+    }
 
     pub fn create_image_request_event(
         id: impl Display,
@@ -82,12 +97,13 @@ pub(crate) mod tests {
 
     #[test]
     fn create_image_request() {
-        let event = create_image_request_event("id", "reference", "registry_auth");
+        let id = Uuid::new_v4();
+        let event = create_image_request_event(id.to_string(), "reference", "registry_auth");
 
         let request = CreateImage::from_event(event).unwrap();
 
         let expect = CreateImage {
-            id: "id".to_string(),
+            id: ReqUuid(id),
             reference: "reference".to_string(),
             registry_auth: "registry_auth".to_string(),
         };
@@ -97,7 +113,8 @@ pub(crate) mod tests {
 
     #[test]
     fn should_convert_to_image() {
-        let event = create_image_request_event("id", "reference", "registry_auth");
+        let id = Uuid::new_v4();
+        let event = create_image_request_event(id.to_string(), "reference", "registry_auth");
 
         let request = CreateImage::from_event(event).unwrap();
 

--- a/edgehog-device-runtime-containers/src/requests/network.rs
+++ b/edgehog-device-runtime-containers/src/requests/network.rs
@@ -22,7 +22,7 @@ use astarte_device_sdk::FromEvent;
 
 use crate::network::Network;
 
-use super::{parse_kv_map, ReqError};
+use super::{parse_kv_map, ReqError, ReqUuid};
 
 /// Request to pull a Docker Network.
 #[derive(Debug, Clone, FromEvent, PartialEq, Eq, PartialOrd, Ord)]
@@ -32,7 +32,7 @@ use super::{parse_kv_map, ReqError};
     rename_all = "camelCase"
 )]
 pub struct CreateNetwork {
-    pub(crate) id: String,
+    pub(crate) id: ReqUuid,
     pub(crate) driver: String,
     pub(crate) internal: bool,
     pub(crate) enable_ipv6: bool,
@@ -47,7 +47,7 @@ impl TryFrom<CreateNetwork> for Network<String> {
 
         Ok(Network {
             id: None,
-            name: value.id,
+            name: value.id.to_string(),
             driver: value.driver,
             internal: value.internal,
             enable_ipv6: value.enable_ipv6,
@@ -63,6 +63,7 @@ pub(crate) mod tests {
 
     use astarte_device_sdk::{AstarteType, DeviceEvent, Value};
     use itertools::Itertools;
+    use uuid::Uuid;
 
     use super::*;
 
@@ -94,12 +95,13 @@ pub(crate) mod tests {
 
     #[test]
     fn create_network_request() {
-        let event = create_network_request_event("id", "driver", &["foo=bar", "some="]);
+        let id = Uuid::new_v4();
+        let event = create_network_request_event(id.to_string(), "driver", &["foo=bar", "some="]);
 
         let request = CreateNetwork::from_event(event).unwrap();
 
         let expect = CreateNetwork {
-            id: "id".to_string(),
+            id: ReqUuid(id),
             driver: "driver".to_string(),
             internal: false,
             enable_ipv6: false,


### PR DESCRIPTION
Parse the uuid when converting the event.