### PR TITLE
doc: Add NotifyAccess option to system section

### DIFF
--- a/doc/os_requirements.md
+++ b/doc/os_requirements.md
@@ -59,6 +59,16 @@ feature enabled.
 cargo build --features systemd
 ```
 
+To allow systemd to receive status changes from service, you need to set the
+[NotifyAccess](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#NotifyAccess=) option to
+either `exec` or `main`.
+
+```
+[Service]
+...
+NotifyAccess=exec
+```
+
 #### Forwarder
 
 The forwarder requires [ttyd](https://github.com/tsl0922/ttyd) for sharing terminal over the web.


### PR DESCRIPTION
This specifies access to the socket that should be used to listen for notifications when the “notify” service type is selected.