### PR TITLE
ci(coverage): use grcov to generate a report

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,9 @@ env:
   RUSTC_WRAPPER: "sccache"
   # Enable logging otherwise the logging lines will count as not covered in the test coverage
   RUST_LOG: trace
+defaults:
+  run:
+    shell: bash
 jobs:
   required:
     runs-on: ubuntu-24.04
@@ -51,32 +54,33 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: Run cargo test --locked
-        run: cargo test --locked --all-features --all-targets --workspace
+        run: cargo test --locked --all-features --workspace
       # https://github.com/rust-lang/cargo/issues/6669
       - name: Run cargo test --doc
         run: cargo test --locked --all-features --doc --workspace
   coverage:
     runs-on: ubuntu-24.04
-    name: ubuntu / stable / coverage
+    name: ubuntu / nightly / coverage
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies
         run: |
           sudo apt update
           sudo apt-get install -y libsqlite3-dev libssl-dev libudev-dev libsystemd-dev upower
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools
       - name: Install sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7
-      - name: cargo install cargo-tarpaulin
-        uses: taiki-e/install-action@cargo-tarpaulin
+      - name: Install grcov
+        uses: taiki-e/install-action@grcov
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
-      - name: Run cargo-tarpaulin with xml output
-        run: cargo +stable tarpaulin --engine llvm --locked --all-features --ignore-tests --packages edgehog-device-runtime edgehog-device-runtime-containers edgehog-device-runtime-forwarder --exclude-files src/main.rs --out xml -- --test-threads 1
+      - name: Generate coverage
+        run: |
+          EXPORT_FOR_CI=1 ./scripts/coverage.sh
       # Upload the coverage if we are not a PR from a fork, see ".github/workflows/coverage.yaml"
       - name: Upload to codecov.io
         if: ${{ github.event_name == 'push' }}
@@ -98,4 +102,6 @@ jobs:
           name: coverage
           path: |
             pr_number
-            cobertura.xml
+            coverage-edgehog-device-runtime.info
+            coverage-edgehog-device-runtime-containers.info
+            coverage-edgehog-device-runtime-forwarder.info

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# This file is part of Edgehog.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -exEuo pipefail
+
+# Output directories for the profile files and coverage
+#
+# You'll find the coverage report and `lcov` file under: $CARGO_TARGET_DIR/debug/coverage/
+#
+# Use absolute paths every where
+CARGO_TARGET_DIR=$(
+    cargo metadata --format-version 1 --no-deps --locked |
+        jq '.target_directory' --raw-output
+)
+export CARGO_TARGET_DIR
+SRC_DIR="$(
+    cargo +nightly locate-project |
+        jq .root --raw-output |
+        xargs dirname
+)"
+export SRC_DIR
+export PROFS_DIR="$CARGO_TARGET_DIR/profs"
+export LLVM_PROFILE_FILE="$PROFS_DIR/coverage-%p-%m.profraw"
+export COVERAGE_OUT_DIR="$CARGO_TARGET_DIR/debug/coverage"
+
+# This require a nightly compiler
+#
+# Rustc options:
+#
+# - `instrument-coverage`: enable coverage for all
+# - `coverage-options=branch``: enable block and branch coverage (unstable option)
+#
+# See: https://doc.rust-lang.org/rustc/instrument-coverage.html
+export RUSTFLAGS="-Cinstrument-coverage -Zcoverage-options=branch"
+export CARGO_INCREMENTAL=0
+
+# Helpful for testing changes in the generation options
+if [[ ${1:-} != '--no-gen' ]]; then
+    cargo +nightly clean
+
+    mkdir -p "$COVERAGE_OUT_DIR"
+    mkdir -p "$PROFS_DIR"
+
+    cargo +nightly test --locked --all-features --tests --no-fail-fast -p edgehog-device-runtime
+    cargo +nightly test --locked --all-features --tests --no-fail-fast -p edgehog-device-runtime-containers
+    cargo +nightly test --locked --all-features --tests --no-fail-fast -p edgehog-device-runtime-forwarder
+fi
+
+find_target_tool() {
+    local libdir
+    local tool_path
+
+    libdir=$(rustup run nightly rustc --print target-libdir)
+    tool_path=$(realpath "$libdir/../bin/$1")
+
+    echo "$tool_path"
+}
+
+rustup_llvm_profdata=$(find_target_tool llvm-profdata)
+rustup_llvm_cov=$(find_target_tool llvm-cov)
+
+LLVM_PROFDATA=${LLVM_PROFDATA:-$rustup_llvm_profdata}
+LLVM_COV=${LLVM_COV:-$rustup_llvm_cov}
+
+$LLVM_PROFDATA merge -sparse "$PROFS_DIR/"*.profraw -o "$PROFS_DIR/coverage.profdata"
+
+object_files() {
+    tests=$(
+        cargo +nightly test --tests --all-features --no-run --message-format=json "$@" |
+            jq -r "select(.profile.test == true) | .filenames[]" |
+            grep -v dSYM -
+    )
+
+    for file in $tests; do
+        printf "%s %s " -object "$file"
+    done
+}
+
+export_lcov() {
+    local src
+    if [[ $1 == 'edgehog-device-runtime' ]]; then
+        src="$SRC_DIR/src"
+    else
+        src="$SRC_DIR/$1/src"
+    fi
+
+    # shellcheck disable=2086,2046
+    $LLVM_COV export \
+        -format=lcov \
+        -ignore-filename-regex='/.cargo/registry' \
+        -instr-profile="$PROFS_DIR/coverage.profdata" \
+        -ignore-filename-regex='.*test\.rs' \
+        -ignore-filename-regex='.*mock\.rs' \
+        -sources "$src" $(object_files -p "$1") \
+        >"$COVERAGE_OUT_DIR/$1/lcov.info"
+}
+
+filter_lcov() {
+    local src
+    if [[ $1 == 'edgehog-device-runtime' ]]; then
+        src="$SRC_DIR"
+    else
+        src="$SRC_DIR/$1"
+    fi
+
+    grcov \
+        "$COVERAGE_OUT_DIR/$1/lcov.info" \
+        --binary-path "$CARGO_TARGET_DIR/debug" \
+        --output-path "$COVERAGE_OUT_DIR/$1/" \
+        --source-dir "$src" \
+        --branch \
+        --llvm \
+        --excl-start 'mod test(s)?' \
+        --output-type lcov,html
+}
+
+list=(
+    'edgehog-device-runtime'
+    'edgehog-device-runtime-containers'
+    'edgehog-device-runtime-forwarder'
+)
+
+for p in "${list[@]}"; do
+    mkdir -p "$COVERAGE_OUT_DIR/$p/"
+
+    export_lcov "$p"
+
+    filter_lcov "$p"
+
+    cp -v "$COVERAGE_OUT_DIR/$p/lcov" "$COVERAGE_OUT_DIR/coverage-$p.info"
+
+    if [[ -n "${EXPORT_FOR_CI:-}" ]]; then
+        cp -v "$COVERAGE_OUT_DIR/$p/lcov" "$PWD/coverage-$p.info"
+    fi
+done

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -75,6 +75,7 @@ impl<D> ContainerService<D> {
         config: ContainersConfig,
         store_dir: &Path,
     ) -> Result<Self, ServiceError> {
+        // TODO: run this logic with the retry
         let client = Docker::connect().await?;
 
         let handle = Handle::open(store_dir.join("state.db"))

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -131,10 +131,13 @@ impl<T> Runtime<T> {
     {
         let (container_tx, container_rx) = mpsc::unbounded_channel();
 
-        let containers =
-            crate::containers::ContainerService::new(client, config, store_dir).await?;
+        let store_dir = store_dir.to_owned();
+        tasks.spawn(async move {
+            let containers =
+                crate::containers::ContainerService::new(client, config, &store_dir).await?;
 
-        tasks.spawn(async move { containers.spawn_unbounded(container_rx).await });
+            containers.spawn_unbounded(container_rx).await
+        });
 
         Ok(container_tx)
     }


### PR DESCRIPTION
Enable branch coverage and use rustc directly for the coverage. This simplifies the compilation step that had failed often with cargo-tarpaulin.