### PR TITLE
feat(reboot): add custom reboot

### DIFF
--- a/src/ota/ota_handler_test.rs
+++ b/src/ota/ota_handler_test.rs
@@ -436,6 +436,12 @@ async fn ota_event_update_success() {
         .returning(|| deploy_status_stream([DeployStatus::Completed { signal: 0 }]));
 
     system_update
+        .expect_reboot()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(|| Ok(()));
+
+    system_update
         .expect_boot_slot()
         .once()
         .in_sequence(&mut seq)


### PR DESCRIPTION
Remove the direct reboot command and add a signal to the RAUC interface to wait and signal reboot errors to the device runtime.