### PR TITLE
chore(release): use "thin" instead of "fat" lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,11 @@ rust-version = "1.72"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.release-minimal]
+[profile.release-optimized]
 inherits = "release"
 strip = true
-lto = true
+# Similar to fat in term of performances, but takes substantially less time to run
+lto = "thin"
 debug = true
 # Supported by all platform
 split-debuginfo = "packed"


### PR DESCRIPTION
This achieves similar performance while taking substantial less time.