### PR TITLE
feat(containers): add DeploymentEvent Started and Stopped 

### DIFF
--- a/edgehog-device-runtime-containers/src/resource/mod.rs
+++ b/edgehog-device-runtime-containers/src/resource/mod.rs
@@ -37,7 +37,7 @@ pub(crate) mod image;
 pub(crate) mod network;
 pub(crate) mod volume;
 
-/// Error returned from a [`Resource`] operation.
+/// Error returned from a Resource operation.
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum ResourceError {
     /// couldn't publish resource property


### PR DESCRIPTION
Add the Started and Stopped statuses to the deployment event. This will
send a datastream with a timestamp in addition to setting the Started
state of the property.

The DatastreamEvent is an `explicit_timestamp`, so we use the sender
timestamp and not the reception one.

