### PR TITLE
 fix(container): work around on image deletion with same digest

### DIFF
--- a/edgehog-device-runtime-containers/src/resource/mod.rs
+++ b/edgehog-device-runtime-containers/src/resource/mod.rs
@@ -60,6 +60,7 @@ pub enum ResourceError {
 
 #[derive(Debug)]
 pub(crate) struct Context<'a, D> {
+    /// Id of the resource
     pub(crate) id: Uuid,
     pub(crate) store: &'a mut StateStore,
     pub(crate) device: &'a mut D,


### PR DESCRIPTION
This is a HACK to make the deletion work when two images have the same digest.