### PR TITLE
fix(containers): send events to the service loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,8 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "edgehog-device-runtime-proto"
-version = "0.10.0-aplha.1"
-source = "git+https://github.com/edgehog-device-manager/edgehog-device-runtime-proto#0c7d5338ba92c1c92ffcb724593cd447d46abe83"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12807d2216753a325df14ca0d086932ad9cf7daf0da581b14cbd6627db49ccbd"
 dependencies = [
  "chrono",
  "prost 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ displaydoc = "0.2.5"
 edgehog-containers = { package = "edgehog-device-runtime-containers", path = "./edgehog-device-runtime-containers", version = "=0.9.1" }
 edgehog-device-forwarder-proto = "0.1.0"
 edgehog-forwarder = { package = "edgehog-device-runtime-forwarder", path = "./edgehog-device-runtime-forwarder", version = "=0.9.1" }
-edgehog-proto = { package = "edgehog-device-runtime-proto", git = "https://github.com/edgehog-device-manager/edgehog-device-runtime-proto" }
+edgehog-proto = { package = "edgehog-device-runtime-proto", version = "0.10.0" }
 edgehog-service = { package = "edgehog-device-runtime-service", path = "./edgehog-device-runtime-service", version = "=0.9.1" }
 edgehog-store = { package = "edgehog-device-runtime-store", path = "./edgehog-device-runtime-store", version = "=0.9.1" }
 eyre = "0.6.12"

--- a/e2e-test-containers/src/receive.rs
+++ b/e2e-test-containers/src/receive.rs
@@ -68,10 +68,7 @@ where
     Ok(())
 }
 
-async fn runtime_listen<D>(mut listener: RuntimeListener<D>) -> color_eyre::Result<()>
-where
-    D: Client + Send + Sync + 'static,
-{
+async fn runtime_listen(mut listener: RuntimeListener) -> color_eyre::Result<()> {
     listener.handle_events().await?;
 
     Ok(())
@@ -107,7 +104,7 @@ where
 
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-    let listener = RuntimeListener::new(client.clone(), device.clone(), store.clone());
+    let listener = RuntimeListener::new(client.clone(), store.clone(), tx.clone());
     let stats = StatsMonitor::with_handle(client.clone(), store.clone());
     let handle = ServiceHandle::new(device.clone(), store.clone(), tx);
     let service = Service::new(client, device.clone(), rx, store);

--- a/edgehog-device-runtime-containers/src/resource/image.rs
+++ b/edgehog-device-runtime-containers/src/resource/image.rs
@@ -123,4 +123,20 @@ where
 
         Ok(())
     }
+
+    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
+        let Some(mut resource) = ctx.store.find_image(ctx.id).await? else {
+            warn!("couldn't find image");
+
+            return Ok(());
+        };
+
+        let pulled = resource.image.inspect(ctx.client).await?.is_some();
+
+        AvailableImage::new(&ctx.id)
+            .send(ctx.device, pulled)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/edgehog-device-runtime-containers/src/resource/mod.rs
+++ b/edgehog-device-runtime-containers/src/resource/mod.rs
@@ -107,6 +107,8 @@ where
 
     fn unset(&mut self, ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
 
+    fn refresh(ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
+
     async fn up(mut ctx: Context<'_, D>) -> Result<Self> {
         let (state, mut resource) = Self::fetch(&mut ctx).await?;
 


### PR DESCRIPTION
This prevents concurrency problems when changing properties during the
deletion of a resource.

Closes #643 