### PR TITLE
feat(rauc): add option to configure the dbus_socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - Unreleased
+
+### Added
+
+- Configuration option `[ota.rauc]` with field `dbus_socket` to select either the session or system
+  bus [#651](https://github.com/edgehog-device-manager/edgehog-device-runtime/pull/651)
+
 ## [0.10.0] - 2025-11-05
 
 ### Changed

--- a/src/ota/config.rs
+++ b/src/ota/config.rs
@@ -16,6 +16,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt::Display;
+
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
@@ -24,6 +26,9 @@ pub struct OtaConfig {
     pub reboot: Reboot,
     #[serde(default)]
     pub streaming: bool,
+    /// RAUC configuration for the OTA
+    #[serde(default)]
+    pub rauc: RaucConfig,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
@@ -32,6 +37,34 @@ pub enum Reboot {
     #[default]
     Default,
     External,
+}
+
+/// Configuration for RAUC
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+pub struct RaucConfig {
+    /// DBUS socket to connect to
+    #[serde(default)]
+    pub dbus_socket: RaucDbus,
+}
+
+/// DBUS socket to comunicate with the RAUC service
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RaucDbus {
+    /// Uses the system bus
+    #[default]
+    System,
+    /// Uses the current user session bus
+    Session,
+}
+
+impl Display for RaucDbus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RaucDbus::System => write!(f, "system"),
+            RaucDbus::Session => write!(f, "session"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -52,6 +85,9 @@ mod tests {
         let exp = OtaConfig {
             reboot: Reboot::External,
             streaming: true,
+            rauc: RaucConfig {
+                dbus_socket: RaucDbus::System,
+            },
         };
 
         assert_eq!(config, exp);
@@ -67,6 +103,29 @@ mod tests {
         let exp = OtaConfig {
             reboot: Reboot::Default,
             streaming: false,
+            rauc: RaucConfig {
+                dbus_socket: RaucDbus::System,
+            },
+        };
+
+        assert_eq!(config, exp);
+    }
+
+    #[test]
+    fn should_deserialize_rauc() {
+        let string = r#"
+        [rauc]
+        dbus_socket = "session"
+        "#;
+
+        let config: OtaConfig = toml::from_str(string).unwrap();
+
+        let exp = OtaConfig {
+            reboot: Reboot::Default,
+            streaming: false,
+            rauc: RaucConfig {
+                dbus_socket: RaucDbus::Session,
+            },
         };
 
         assert_eq!(config, exp);

--- a/src/ota/ota_handler.rs
+++ b/src/ota/ota_handler.rs
@@ -100,7 +100,7 @@ impl OtaHandler {
         let (publisher_tx, publisher_rx) = mpsc::channel(8);
         let (ota_tx, ota_rx) = mpsc::channel(MAX_OTA_OPERATION);
 
-        let system_update = OTARauc::connect().await?;
+        let system_update = OTARauc::connect(&opts.ota).await?;
 
         let state_repository = FileStateRepository::new(&opts.store_directory, "state.json");
 


### PR DESCRIPTION
Add the [ota.rauc] option and dbus_socket to chose to use either the system or the session bus to comunicate with RAUC.