### PR TITLE
fix(container): improve deletion query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - Unreleased
+
+### Fixed
+
+- Improve query to prevent conflicts when deleting shared resources (volume, netwroks, ...)
+  [#654](https://github.com/edgehog-device-manager/edgehog-device-runtime/pull/654)
+
 ## [0.10.1] - 2025-11-28
 
 ### Added

--- a/edgehog-device-runtime-containers/src/resource/deployment.rs
+++ b/edgehog-device-runtime-containers/src/resource/deployment.rs
@@ -46,7 +46,7 @@ pub(crate) type DeploymentRow = (
     Option<ContainerDeviceMapping>,
 );
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct Deployment {
     pub(crate) containers: HashSet<Uuid>,
     pub(crate) images: HashSet<Uuid>,


### PR DESCRIPTION
Make the exclude clause use the actual column since it would return (container_id, res_id) which in some cases will differ for shared resources and result in a conflict when deleting because still in use.

Closes #653 