### PR TITLE
fix(ota): save the state file in the deployment stage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - Unreleased
+
+### Fixed
+
+- Save the state file in the deployment step to fix the streaming feature
+  [#663](https://github.com/edgehog-device-manager/edgehog-device-runtime/pull/663)
+
 ## [0.9.2] - 2025-12-18
 
 ### Added


### PR DESCRIPTION
This fixes a bug where the state would not be saved if the streaming
features was activated, since before the boot-slot was checked and the
files was saved in the download step.
