### PR TITLE
fix(containers): make port bindings work for different protocols

### DIFF
--- a/edgehog-device-runtime-containers/CHANGELOG.md
+++ b/edgehog-device-runtime-containers/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Make port bindings work for different protocols
+  [#668](https://github.com/edgehog-device-manager/edgehog-device-runtime/pull/668)
+
 ## [0.10.3] - 2025-12-19
 
 ## [0.9.2] - 2025-12-18

--- a/edgehog-device-runtime-containers/src/docker/container.rs
+++ b/edgehog-device-runtime-containers/src/docker/container.rs
@@ -522,6 +522,13 @@ impl From<&Container> for ContainerCreateBody {
             maximum_retry_count: None,
         };
 
+        // NOTE: to expose ports you need to set both port_bindings in the host_config and exposed_ports
+        let exposed_ports = port_bindings
+            .keys()
+            .cloned()
+            .map(|k| (k, HashMap::new()))
+            .collect();
+
         let host_config = HostConfig {
             restart_policy: Some(restart_policy),
             binds: Some(binds),
@@ -556,6 +563,7 @@ impl From<&Container> for ContainerCreateBody {
             env: Some(env),
             host_config: Some(host_config),
             networking_config: Some(networking_config),
+            exposed_ports: Some(exposed_ports),
             ..Default::default()
         }
     }


### PR DESCRIPTION
To make the port bindings work you need to set both the ExposedPort and PortBinding keys when creating a container.