### PR TITLE
feat(fileTransfer): check the digest for existing files 

### DIFF
--- a/src/file_transfer/file_system/mod.rs
+++ b/src/file_transfer/file_system/mod.rs
@@ -17,20 +17,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use pin_project::pin_project;
 use tokio::fs::File;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, BufReader};
 use tokio_stream::StreamExt;
-use tracing::{info, instrument, trace};
+use tracing::{error, info, instrument, trace};
 use uuid::Uuid;
 
 use crate::file_transfer::encoding::tar_gz::TarGzDecoder;
+use crate::io::digest::Digest;
 
-use super::request::Encoding;
 #[cfg(unix)]
 use super::request::FilePermissions;
+use super::request::{Encoding, FileDigest};
 
 pub(super) mod store;
 pub(super) mod stream;
@@ -69,6 +70,33 @@ impl WriteHandle {
     #[cfg(unix)]
     fn mask(mode: u32) -> u32 {
         0o600 | mode
+    }
+
+    #[instrument]
+    pub(crate) async fn try_exists(
+        path: &Path,
+        alg: FileDigest,
+        digest: &[u8],
+    ) -> io::Result<bool> {
+        let file = match File::open(path).await {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(false);
+            }
+            Err(error) => {
+                error!(%error, "couldn't check if file existed");
+
+                return Err(error);
+            }
+        };
+
+        let meta = file.metadata().await?;
+
+        let file = Digest::from_read(file, alg, meta.len()).await?;
+
+        file.into_inner(digest)?;
+
+        Ok(true)
     }
 
     #[instrument(skip(opt))]
@@ -232,5 +260,52 @@ impl AsyncSeek for WriteHandle {
         let this = self.project();
 
         this.file.poll_complete(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempdir::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn try_exists() {
+        let dir = TempDir::new("try_exists").unwrap();
+
+        let content = Uuid::new_v4().to_string();
+
+        let alg = FileDigest::Sha256;
+        let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, content.as_bytes());
+
+        let path = dir.path().join("file.txt");
+
+        tokio::fs::write(&path, &content).await.unwrap();
+
+        let exists = WriteHandle::try_exists(&path, alg, digest.as_ref())
+            .await
+            .unwrap();
+
+        assert!(exists);
+    }
+
+    #[tokio::test]
+    async fn mismatched_digest() {
+        let dir = TempDir::new("try_exists").unwrap();
+
+        let content = Uuid::new_v4().to_string();
+
+        let alg = FileDigest::Sha256;
+        let other_content = Uuid::new_v4().to_string();
+        let digest =
+            aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, other_content.as_bytes());
+
+        let path = dir.path().join("file.txt");
+
+        tokio::fs::write(&path, &content).await.unwrap();
+
+        WriteHandle::try_exists(&path, alg, digest.as_ref())
+            .await
+            .unwrap_err();
     }
 }

--- a/src/file_transfer/file_system/store.rs
+++ b/src/file_transfer/file_system/store.rs
@@ -27,6 +27,7 @@ use tracing::{instrument, trace};
 use uuid::Uuid;
 
 use crate::file_transfer::encoding::Paths;
+use crate::file_transfer::request::FileDigest;
 
 use super::{FileOptions, WriteHandle};
 
@@ -58,10 +59,15 @@ impl<F> FileStorage<F> {
     }
 
     #[instrument(skip(self), ret)]
-    pub(crate) async fn file_exists(&self, id: &Uuid) -> eyre::Result<bool> {
+    pub(crate) async fn file_exists(
+        &self,
+        id: &Uuid,
+        alg: FileDigest,
+        digest: &[u8],
+    ) -> eyre::Result<bool> {
         let path = self.file_path(id);
 
-        tokio::fs::try_exists(&path)
+        WriteHandle::try_exists(&path, alg, digest)
             .await
             .wrap_err_with(|| format!("couldn't access file: {}", path.display()))
     }

--- a/src/file_transfer/mod.rs
+++ b/src/file_transfer/mod.rs
@@ -283,7 +283,12 @@ impl<F, S, C> FileTransfer<F, S, C> {
     where
         F: Space,
     {
-        if self.storage.file_exists(&download.id).await? {
+        let exists = self
+            .storage
+            .file_exists(&download.id, download.digest_type, &download.digest)
+            .await?;
+
+        if exists {
             info!("file already exists");
 
             return Ok(());
@@ -347,11 +352,7 @@ impl<F, S, C> FileTransfer<F, S, C> {
     where
         F: Space,
     {
-        let exists = tokio::fs::try_exists(&path)
-            .await
-            .wrap_err_with(|| format!("couldn't access file: {}", path.display()))?;
-
-        if exists {
+        if WriteHandle::try_exists(&path, download.digest_type, &download.digest).await? {
             info!("file already exists");
 
             return Ok(());

--- a/src/io/digest.rs
+++ b/src/io/digest.rs
@@ -43,17 +43,17 @@ impl<S> Digest<S> {
     }
 
     #[instrument(skip(inner))]
-    pub(crate) async fn from_read(inner: S, digest: FileDigest, start: u64) -> io::Result<Self>
+    pub(crate) async fn from_read(inner: S, digest: FileDigest, seek: u64) -> io::Result<Self>
     where
         S: AsyncRead + Unpin,
     {
         let mut ctx = aws_lc_rs::digest::Context::from(digest);
 
-        let inner = if start == 0 {
+        let inner = if seek == 0 {
             inner
         } else {
             // Read till start
-            let mut reader = BufReader::new(inner.take(start));
+            let mut reader = BufReader::new(inner.take(seek));
 
             while let buf = reader.fill_buf().await?
                 && !buf.is_empty()


### PR DESCRIPTION
If a file we want to download to store or filesystem already exists. We
will read it to make sure that the digests matches the one in the
request.
