### PR TITLE
feat(fileTransfer): configure the service 

### DIFF
--- a/e2e-test/src/main.rs
+++ b/e2e-test/src/main.rs
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@
 
 use astarte_device_sdk::rumqttc::tokio_rustls::rustls;
 use clap::Parser;
+use edgehog_device_runtime::file_transfer::config::FileTransferArgs;
 use edgehog_device_runtime::telemetry::status::hardware_info::HardwareInfo;
 use edgehog_device_runtime::telemetry::status::os_release::{OsInfo, OsRelease};
 use edgehog_device_runtime::telemetry::status::runtime_info::{RUNTIME_INFO, RuntimeInfo};
@@ -154,6 +155,7 @@ async fn main() -> color_eyre::Result<()> {
         service: None,
         #[cfg(target_os = "linux")]
         ota: edgehog_device_runtime::ota::config::OtaConfig::default(),
+        file_transfer: FileTransferArgs::with_store_dir(None, store_path.path()),
     };
 
     let store = connect_store(store_path.path())

--- a/snapshots/edgehog_device_runtime__file_transfer__config__tests__config_roundtrip.snap
+++ b/snapshots/edgehog_device_runtime__file_transfer__config__tests__config_roundtrip.snap
@@ -1,0 +1,7 @@
+---
+source: src/file_transfer/config.rs
+expression: toml_str
+---
+enabled = true
+storage_dir = "/foo/bar"
+storage_reserved = 42

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2022 - 2025 SECO Mind Srl
+// Copyright 2022-2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,6 +43,9 @@ pub struct Config {
 
     #[cfg(all(feature = "zbus", target_os = "linux"))]
     pub ota: Option<edgehog_device_runtime::ota::config::OtaConfig>,
+
+    #[cfg(feature = "file-transfer")]
+    pub file_transfer: Option<edgehog_device_runtime::file_transfer::config::FileTransferConfig>,
 
     pub interfaces_directory: Option<PathBuf>,
     pub store_directory: Option<PathBuf>,
@@ -84,6 +87,13 @@ impl TryFrom<Config> for DeviceManagerOptions {
         #[cfg(all(feature = "zbus", target_os = "linux"))]
         let ota = value.ota.unwrap_or_default();
 
+        #[cfg(feature = "file-transfer")]
+        let file_transfer =
+            edgehog_device_runtime::file_transfer::config::FileTransferArgs::with_store_dir(
+                value.file_transfer,
+                &store_directory,
+            );
+
         Ok(Self {
             astarte_library,
             astarte_device_sdk,
@@ -95,6 +105,8 @@ impl TryFrom<Config> for DeviceManagerOptions {
             service: value.service,
             #[cfg(all(feature = "zbus", target_os = "linux"))]
             ota,
+            #[cfg(feature = "file-transfer")]
+            file_transfer,
             interfaces_directory,
             store_directory,
             download_directory,

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2024 - 2025 SECO Mind Srl
+// Copyright 2024-2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,6 +47,8 @@ pub const MAX_INIT_RETRIES: usize = 10;
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ContainersConfig {
+    #[serde(default = "ContainersConfig::default_enabled")]
+    pub(crate) enabled: bool,
     /// Flag to make the container service is required
     #[serde(default)]
     required: bool,
@@ -56,6 +58,9 @@ pub struct ContainersConfig {
 }
 
 impl ContainersConfig {
+    const fn default_enabled() -> bool {
+        true
+    }
     const fn default_max_retries() -> usize {
         MAX_INIT_RETRIES
     }
@@ -64,6 +69,7 @@ impl ContainersConfig {
 impl Default for ContainersConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             required: false,
             max_retries: Self::default_max_retries(),
         }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -48,9 +48,10 @@ pub struct Runtime<T> {
     cancel: CancellationToken,
     telemetry_tx: mpsc::Sender<TelemetryEvent>,
     #[cfg(feature = "file-transfer")]
-    file_transfer: mpsc::Sender<crate::file_transfer::interface::request::FileTransferRequest>,
+    file_transfer:
+        Option<mpsc::Sender<crate::file_transfer::interface::request::FileTransferRequest>>,
     #[cfg(feature = "containers")]
-    containers_tx: mpsc::Sender<Box<edgehog_containers::requests::ContainerRequest>>,
+    containers_tx: Option<mpsc::Sender<Box<edgehog_containers::requests::ContainerRequest>>>,
     #[cfg(feature = "forwarder")]
     forwarder: crate::forwarder::Forwarder<T>,
     #[cfg(all(feature = "zbus", target_os = "linux"))]
@@ -122,9 +123,9 @@ impl<C> Runtime<C> {
         #[cfg(feature = "file-transfer")]
         let file_transfer = Self::file_transfer(
             client.clone(),
+            opts.file_transfer,
             tasks,
             jobs,
-            opts.store_directory.join("file-store"),
             cancel.child_token(),
         )
         .wrap_err("could't initialize file transfer")?;
@@ -176,11 +177,13 @@ impl<C> Runtime<C> {
     #[cfg(feature = "file-transfer")]
     fn file_transfer(
         device: C,
+        config: crate::file_transfer::config::FileTransferArgs,
         tasks: &mut JoinSet<eyre::Result<()>>,
         jobs: crate::jobs::Queue,
-        store_dir: std::path::PathBuf,
         cancel: CancellationToken,
-    ) -> eyre::Result<mpsc::Sender<crate::file_transfer::interface::request::FileTransferRequest>>
+    ) -> eyre::Result<
+        Option<mpsc::Sender<crate::file_transfer::interface::request::FileTransferRequest>>,
+    >
     where
         C: Client + Send + Sync + 'static,
     {
@@ -192,6 +195,12 @@ impl<C> Runtime<C> {
 
         use self::actor::Persisted;
 
+        if !config.enabled {
+            tracing::info!("file transfer service not enabled");
+
+            return Ok(None);
+        }
+
         let (transfer_tx, transfer_rx) = tokio::sync::mpsc::channel(EVENT_BUFFER);
         let notify = Arc::new(Notify::new());
 
@@ -199,12 +208,12 @@ impl<C> Runtime<C> {
 
         tasks.spawn(ProgressTracker::create(device.clone()).run(progress_rx, cancel.clone()));
         tasks.spawn(
-            FileTransfer::create(jobs.clone(), store_dir, device.clone(), progress_tx)?
+            FileTransfer::create(jobs.clone(), config, device.clone(), progress_tx)?
                 .run(Arc::clone(&notify), cancel.clone()),
         );
         tasks.spawn(file_transfer::Receiver::new(jobs, notify, device).run(transfer_rx, cancel));
 
-        Ok(transfer_tx)
+        Ok(Some(transfer_tx))
     }
 
     #[cfg(feature = "containers")]
@@ -217,10 +226,16 @@ impl<C> Runtime<C> {
         >,
         tasks: &mut JoinSet<eyre::Result<()>>,
         cancel: CancellationToken,
-    ) -> eyre::Result<mpsc::Sender<Box<edgehog_containers::requests::ContainerRequest>>>
+    ) -> eyre::Result<Option<mpsc::Sender<Box<edgehog_containers::requests::ContainerRequest>>>>
     where
         C: Client + Send + Sync + 'static,
     {
+        if !config.enabled {
+            tracing::info!("container service not enabled");
+
+            return Ok(None);
+        }
+
         let (container_tx, container_rx) = mpsc::channel(EVENT_BUFFER);
 
         let containers = crate::containers::ContainerService::new(
@@ -235,7 +250,7 @@ impl<C> Runtime<C> {
 
         tasks.spawn(containers.run(container_rx, cancel));
 
-        Ok(container_tx)
+        Ok(Some(container_tx))
     }
 
     #[cfg(feature = "service")]
@@ -250,9 +265,7 @@ impl<C> Runtime<C> {
         C: Client + Clone + Send + Sync + 'static,
     {
         if !config.enabled {
-            use tracing::debug;
-
-            debug!("local service not enabled");
+            tracing::debug!("local service not enabled");
 
             return;
         }
@@ -341,8 +354,12 @@ impl<C> Runtime<C> {
             }
             #[cfg(feature = "file-transfer")]
             RuntimeEvent::FileTransfer(event) => {
-                if self.file_transfer.send(event).await.is_err() {
-                    error!("couldn't send file transfer event");
+                if let Some(file_transfer) = &self.file_transfer {
+                    if file_transfer.send(event).await.is_err() {
+                        error!("couldn't send file transfer event");
+                    }
+                } else {
+                    error!("received event on file-transfer interface, but the service is disable");
                 }
             }
             #[cfg(all(feature = "zbus", target_os = "linux"))]
@@ -362,8 +379,12 @@ impl<C> Runtime<C> {
             }
             #[cfg(feature = "containers")]
             RuntimeEvent::Container(event) => {
-                if self.containers_tx.send(event).await.is_err() {
-                    error!("couldn't handle the container event")
+                if let Some(containers_tx) = &self.containers_tx {
+                    if containers_tx.send(event).await.is_err() {
+                        error!("couldn't handle the container event")
+                    }
+                } else {
+                    error!("received event on container interface, but the service is disable");
                 }
             }
             #[cfg(feature = "forwarder")]

--- a/src/file_transfer/config.rs
+++ b/src/file_transfer/config.rs
@@ -1,0 +1,145 @@
+// This file is part of Edgehog.
+//
+// Copyright 2026 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the file-transfer service.
+
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Max free space to keep on the device.
+pub const DEFAULT_MAX_FREE_PERCENTAGE: Percentage = Percentage::new(20).unwrap();
+
+/// Value from 0 to 100
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Percentage(u8);
+
+impl Percentage {
+    /// Creates a new percentage.
+    pub const fn new(value: u8) -> Option<Self> {
+        if value <= 100 {
+            Some(Self(value))
+        } else {
+            None
+        }
+    }
+}
+
+impl Deref for Percentage {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for Percentage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Percentage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u8::deserialize(deserializer)?;
+
+        Self::new(value).ok_or(serde::de::Error::invalid_value(
+            serde::de::Unexpected::Unsigned(value.into()),
+            &"an Unsigned integer as percentage between 0 and 100",
+        ))
+    }
+}
+
+/// Configuration for the FileTransfer
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileTransferConfig {
+    /// Enables the file-transfer service
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Sets a custom directory for the `storage` target.
+    ///
+    /// The default is the subdirectory `file-store/` in the configured `store_directory`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_dir: Option<PathBuf>,
+    /// Percentage of free space reserved for the system.
+    ///
+    /// The default is the 20% of the free space can not bee occupied by a file transfer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_reserved: Option<Percentage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileTransferArgs {
+    pub(crate) enabled: bool,
+    pub(crate) storage_dir: PathBuf,
+    pub(crate) storage_reserved: Percentage,
+}
+
+impl FileTransferArgs {
+    /// Converts a configuration to the arguments to start the file transfer
+    pub fn with_store_dir(config: Option<FileTransferConfig>, store_dir: &Path) -> Self {
+        let config = config.unwrap_or_default();
+
+        let enabled = config.enabled.unwrap_or(true);
+        let storage_dir = config
+            .storage_dir
+            .unwrap_or_else(|| store_dir.join("file-store"));
+        let storage_reserved = config
+            .storage_reserved
+            .unwrap_or(DEFAULT_MAX_FREE_PERCENTAGE);
+
+        Self {
+            enabled,
+            storage_dir,
+            storage_reserved,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::with_insta;
+
+    use super::*;
+
+    #[test]
+    fn config_roundtrip() {
+        let exp = FileTransferConfig {
+            enabled: Some(true),
+            storage_dir: Some(PathBuf::from("/foo/bar")),
+            storage_reserved: Some(Percentage::new(42).unwrap()),
+        };
+
+        let toml_str = toml::to_string_pretty(&exp).unwrap();
+
+        let res: FileTransferConfig = toml::from_str(&toml_str).unwrap();
+
+        assert_eq!(res, exp);
+
+        with_insta!({
+            insta::assert_snapshot!(toml_str);
+        });
+    }
+}

--- a/src/file_transfer/file_system/store.rs
+++ b/src/file_transfer/file_system/store.rs
@@ -26,6 +26,7 @@ use eyre::WrapErr;
 use tracing::{instrument, trace};
 use uuid::Uuid;
 
+use crate::file_transfer::config::Percentage;
 use crate::file_transfer::encoding::Paths;
 use crate::file_transfer::request::FileDigest;
 
@@ -39,8 +40,11 @@ pub(crate) struct FileStorage<F> {
 }
 
 impl FileStorage<Fs> {
-    pub(crate) fn new(dir: PathBuf) -> Self {
-        Self { fs: Fs {}, dir }
+    pub(crate) fn new(dir: PathBuf, reserved: Percentage) -> Self {
+        Self {
+            fs: Fs { reserved },
+            dir,
+        }
     }
 }
 
@@ -142,7 +146,10 @@ pub(crate) trait Space {
 }
 
 #[derive(Debug)]
-pub(crate) struct Fs {}
+pub(crate) struct Fs {
+    #[expect(unused)]
+    reserved: Percentage,
+}
 
 impl Fs {}
 
@@ -169,6 +176,7 @@ mod tests {
     use tempdir::TempDir;
     use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
+    use crate::file_transfer::config::DEFAULT_MAX_FREE_PERCENTAGE;
     #[cfg(unix)]
     use crate::file_transfer::request::FilePermissions;
 
@@ -187,7 +195,10 @@ mod tests {
     fn fs_storage() -> (FileStorage<Fs>, TempDir) {
         let dir = TempDir::new("fs_storage").expect("couldn't create temp directory");
 
-        (FileStorage::new(dir.path().to_path_buf()), dir)
+        (
+            FileStorage::new(dir.path().to_path_buf(), DEFAULT_MAX_FREE_PERCENTAGE),
+            dir,
+        )
     }
 
     fn mock_fs_storage(mock: MockSpace) -> (FileStorage<MockSpace>, TempDir) {

--- a/src/file_transfer/mod.rs
+++ b/src/file_transfer/mod.rs
@@ -44,6 +44,7 @@ use crate::io::progress::{Progress, ProgressHandle};
 use crate::jobs::Queue;
 use crate::{file_transfer::interface::status::FileTransferResponse, io::digest::Digest};
 
+use self::config::FileTransferArgs;
 use self::encoding::Paths;
 use self::encoding::tar_gz::TarGzBuilder;
 use self::file_system::store::{FileStorage, Fs, Space};
@@ -55,6 +56,7 @@ use self::request::download::{Destination, Download};
 use self::request::upload::{Source, Upload};
 use self::request::{Encoding, JobTag, Request};
 
+pub mod config;
 mod encoding;
 pub(crate) mod file_system;
 pub(crate) mod http;
@@ -163,18 +165,20 @@ pub(crate) struct FileTransfer<F, S, C> {
 impl<C> FileTransfer<Fs, SysPipe, C> {
     pub fn create(
         queue: Queue,
-        dir: PathBuf,
+        args: FileTransferArgs,
         device: C,
         tracker: watch::Sender<Option<FileTransferProgress>>,
     ) -> eyre::Result<Self>
     where
         C: astarte_device_sdk::Client + Send + Sync + 'static,
     {
+        debug_assert!(args.enabled);
+
         let client = FtHttpClient::create().wrap_err("can't construct file transfer client")?;
 
         Ok(Self {
             queue,
-            storage: FileStorage::new(dir),
+            storage: FileStorage::new(args.storage_dir, args.storage_reserved),
             stream: Streaming::new(),
             client,
             device,
@@ -707,6 +711,7 @@ mod tests {
     use tempdir::TempDir;
     use uuid::Uuid;
 
+    use super::config::DEFAULT_MAX_FREE_PERCENTAGE;
     use super::request::{FileDigest, FilePermissions};
     use super::*;
 
@@ -736,8 +741,13 @@ mod tests {
 
         let queue = Queue::new(db);
 
+        let args = FileTransferArgs {
+            enabled: true,
+            storage_dir: dir.path().to_path_buf(),
+            storage_reserved: DEFAULT_MAX_FREE_PERCENTAGE,
+        };
         (
-            FileTransfer::create(queue, dir.path().to_path_buf(), device, tracker).unwrap(),
+            FileTransfer::create(queue, args, device, tracker).unwrap(),
             dir,
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod data;
 mod device;
 pub mod error;
 #[cfg(feature = "file-transfer")]
-pub(crate) mod file_transfer;
+pub mod file_transfer;
 #[cfg(feature = "forwarder")]
 mod forwarder;
 pub(crate) mod http;
@@ -61,7 +61,7 @@ pub enum AstarteLibrary {
     AstarteMessageHub,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct DeviceManagerOptions {
     pub astarte_library: AstarteLibrary,
     pub astarte_device_sdk: Option<AstarteDeviceSdkConfigOptions>,
@@ -71,6 +71,8 @@ pub struct DeviceManagerOptions {
     pub containers: containers::ContainersConfig,
     #[cfg(feature = "service")]
     pub service: Option<edgehog_service::config::Config>,
+    #[cfg(feature = "file-transfer")]
+    pub file_transfer: self::file_transfer::config::FileTransferArgs,
     #[cfg(all(feature = "zbus", target_os = "linux"))]
     pub ota: self::ota::config::OtaConfig,
     pub interfaces_directory: PathBuf,


### PR DESCRIPTION
Add a `file_transfer` section to the configuration file:

- `enabled`: flag to start the file transfer service
- `storage_dir`: directory for the storage destination and source
- `storage_reserved`: percentage of free space to keep for the system