### PR TITLE
chore(fileTransfer): fix query to update status to the correct job 

### DIFF
--- a/edgehog-device-runtime-store/src/models/job/mod.rs
+++ b/edgehog-device-runtime-store/src/models/job/mod.rs
@@ -29,21 +29,21 @@ pub mod job_type;
 pub mod status;
 
 /// A job in the queue
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Insertable, Identifiable, AsChangeset, HasQuery)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, HasQuery, Insertable, Identifiable, AsChangeset)]
 #[diesel(table_name = crate::schema::runtime::job_queue)]
-#[diesel(primary_key(id, job_type))]
+#[diesel(primary_key(id, job_type, tag))]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
 pub struct Job {
     /// Unique id for the Job Type
     pub id: SqlUuid,
     /// Job type in the queue
     pub job_type: JobType,
+    /// Tag to identify the type of data stored
+    pub tag: i32,
     /// Status of the job
     pub status: JobStatus,
     /// Version of the serialized data
     pub version: i32,
-    /// Tag to identify the type of data stored
-    pub tag: i32,
     /// When the job should be scheduled
     pub schedule_at: Option<i64>,
     /// Serialized additional data for the job

--- a/src/file_transfer/http/mod.rs
+++ b/src/file_transfer/http/mod.rs
@@ -58,6 +58,7 @@ impl FtHttpClient {
         Ok(Self { client })
     }
 
+    #[instrument(skip(self, headers, start, total_len))]
     pub(crate) async fn download(
         &self,
         url: &Url,
@@ -66,8 +67,12 @@ impl FtHttpClient {
         total_len: Option<u64>,
     ) -> eyre::Result<FileDownloadResponse> {
         if start == 0 {
+            trace!("making full request");
+
             return self.full_request(url, headers, total_len).await;
         }
+
+        trace!(start, "making range request");
 
         headers.insert(
             reqwest::header::RANGE,

--- a/src/file_transfer/mod.rs
+++ b/src/file_transfer/mod.rs
@@ -266,13 +266,15 @@ impl<F, S, C> FileTransfer<F, S, C> {
     {
         let id = job.transfer();
 
+        info!("starting file transfer");
+
         let result = match job {
             Request::Download(download) => self.download(&download).await,
             Request::Upload(upload) => self.upload(&upload).await,
         };
 
         match result {
-            Ok(_) => self.job_done(id).await,
+            Ok(()) => self.job_done(id).await,
             Err(error) => {
                 error!(
                     error = format!("{error:#}"),
@@ -599,6 +601,7 @@ impl<F, S, C> FileTransfer<F, S, C> {
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn job_done(&mut self, transfer: FileTransferId) -> eyre::Result<()>
     where
         C: Client + Send + Sync + 'static,
@@ -610,6 +613,8 @@ impl<F, S, C> FileTransfer<F, S, C> {
             .update(&id, JobType::FileTransfer, tag.into(), JobStatus::Done)
             .await
             .wrap_err("couldn't update job status")?;
+
+        info!("job success");
 
         FileTransferResponse::success(transfer)
             .send(&mut self.device)
@@ -635,6 +640,8 @@ impl<F, S, C> FileTransfer<F, S, C> {
             .update(&id, JobType::FileTransfer, tag.into(), JobStatus::Error)
             .await
             .wrap_err("couldn't update job status")?;
+
+        error!("job error");
 
         FileTransferResponse::runtime_error(id, direction, error)
             .send(&mut self.device)

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -27,7 +27,7 @@ use edgehog_store::models::job::job_type::JobType;
 use edgehog_store::models::job::status::JobStatus;
 use edgehog_store::schema::runtime::job_queue;
 use eyre::Context;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, trace};
 use uuid::Uuid;
 
 use self::timestamp::Unix;
@@ -158,19 +158,26 @@ impl Queue {
         let job = self
             .db
             .for_write(move |write| {
-                let Some(mut job) = Job::query()
+                let optional = Job::query()
                     .filter(job_queue::job_type.eq(job_type))
                     .filter(job_queue::status.eq(JobStatus::Pending))
                     .order_by(job_queue::created_at.asc())
                     .first(write)
-                    .optional()?
-                else {
+                    .optional()?;
+
+                let Some(mut job) = optional else {
                     return Ok(None);
                 };
 
                 job.status = JobStatus::InProgress;
 
-                update(job_queue::table).set(&job).execute(write)?;
+                let row_changed = update(&job)
+                    .set(job_queue::status.eq(JobStatus::InProgress))
+                    .execute(write)?;
+
+                debug_assert_eq!(row_changed, 1);
+
+                trace!(row_changed, id = %job.id, "updated job to in progress");
 
                 Ok(Some(job))
             })
@@ -224,7 +231,11 @@ impl Queue {
 
                 job.status = JobStatus::InProgress;
 
-                update(job_queue::table).set(&job).execute(write)?;
+                let row_changed = update(&job)
+                    .set(job_queue::status.eq(JobStatus::InProgress))
+                    .execute(write)?;
+
+                debug_assert_eq!(row_changed, 1);
 
                 Ok(Some(job))
             })


### PR DESCRIPTION
Update the single job status to inprogress with the correct query when
getting the next job.

Before we where using diesel Identifiable incorrectly and ending up
updating multiple jobs at once.