### PR TITLE
fix(containers): update properties when fetching the resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -1459,7 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3474,7 +3474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3540,7 +3540,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3977,7 +3977,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4741,7 +4741,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/edgehog-device-runtime-containers/src/docker/volume.rs
+++ b/edgehog-device-runtime-containers/src/docker/volume.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2023-2024 SECO Mind Srl
+// Copyright 2023, 2024, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,10 +25,9 @@ use std::{
     sync::OnceLock,
 };
 
-use bollard::{
-    errors::Error as BollardError, models::Volume as DockerVolume,
-    query_parameters::RemoveVolumeOptions, secret::VolumeCreateRequest,
-};
+use bollard::errors::Error as BollardError;
+use bollard::models::{Volume as DockerVolume, VolumeCreateRequest};
+use bollard::query_parameters::RemoveVolumeOptions;
 use tracing::{debug, error, instrument, trace, warn};
 use uuid::Uuid;
 

--- a/edgehog-device-runtime-containers/src/local.rs
+++ b/edgehog-device-runtime-containers/src/local.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,10 +20,10 @@
 
 use std::collections::HashMap;
 
-use bollard::models::ContainerStateStatusEnum;
-use bollard::models::ContainerSummary;
+use bollard::models::{
+    ContainerInspectResponse, ContainerStateStatusEnum, ContainerStatsResponse, ContainerSummary,
+};
 use bollard::query_parameters::ListContainersOptionsBuilder;
-use bollard::secret::{ContainerInspectResponse, ContainerStatsResponse};
 use edgehog_store::conversions::SqlUuid;
 use edgehog_store::models::containers::container::ContainerStatus;
 use tracing::trace;

--- a/edgehog-device-runtime-containers/src/resource/container.rs
+++ b/edgehog-device-runtime-containers/src/resource/container.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -95,13 +95,56 @@ impl ContainerResource {
 
         Ok(())
     }
+
+    async fn update_status<D>(&mut self, ctx: &mut Context<'_, D>) -> Result<bool>
+    where
+        D: Client + Send + Sync + 'static,
+    {
+        let Some(inspect) = self.container.inspect(ctx.client).await? else {
+            debug!("container deleted");
+
+            AvailableContainer::new(&ctx.id)
+                .send(ctx.device, PropertyStatus::Received)
+                .await?;
+
+            return Ok(false);
+        };
+
+        let Some(container_state) = inspect.state.and_then(|state| state.status) else {
+            warn!("couldn't find status in inspect container response");
+
+            return Ok(false);
+        };
+
+        let (status, exists) = match container_state {
+            ContainerStateStatusEnum::CREATED => (PropertyStatus::Created, true),
+            ContainerStateStatusEnum::RUNNING | ContainerStateStatusEnum::RESTARTING => {
+                (PropertyStatus::Running, true)
+            }
+            ContainerStateStatusEnum::REMOVING => (PropertyStatus::Received, false),
+            ContainerStateStatusEnum::EXITED | ContainerStateStatusEnum::DEAD => {
+                (PropertyStatus::Stopped, true)
+            }
+            ContainerStateStatusEnum::PAUSED | ContainerStateStatusEnum::EMPTY => {
+                debug!(%container_state, "weird state");
+
+                (PropertyStatus::Created, true)
+            }
+        };
+
+        AvailableContainer::new(&ctx.id)
+            .send(ctx.device, status)
+            .await?;
+
+        Ok(exists)
+    }
 }
 
 impl<D> Resource<D> for ContainerResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableContainer::new(&ctx.id)
             .send(ctx.device, PropertyStatus::Received)
             .await?;
@@ -109,6 +152,8 @@ where
         ctx.store
             .update_container_status(ctx.id, ContainerStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -118,27 +163,25 @@ impl<D> Create<D> for ContainerResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let mut container =
-            ctx.store
-                .find_container(ctx.id)
-                .await?
-                .ok_or(ResourceError::Missing {
-                    id: ctx.id,
-                    resource: "container",
-                })?;
+    const RESOURCE_NAME: &str = "container";
 
-        let exists = container.inspect(ctx.client).await?.is_some();
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(container) = ctx.store.find_container(ctx.id).await? else {
+            return Ok(None);
+        };
 
-        let resource = ContainerResource::new(container);
+        let mut resource = ContainerResource::new(container);
+
+        let exists = resource.update_status(ctx).await?;
+
         if exists {
             ctx.store
                 .update_container_local_id(ctx.id, resource.container.id.id.clone())
                 .await?;
 
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -172,52 +215,6 @@ where
         AvailableContainer::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_container(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        let Some(mut container) = ctx.store.find_container(ctx.id).await? else {
-            warn!("couldn't find container");
-
-            return Ok(());
-        };
-
-        let Some(inspect) = container.inspect(ctx.client).await? else {
-            debug!("container deleted");
-
-            AvailableContainer::new(&ctx.id)
-                .send(ctx.device, PropertyStatus::Received)
-                .await?;
-
-            return Ok(());
-        };
-
-        let Some(container_state) = inspect.state.and_then(|state| state.status) else {
-            warn!("couldn't find status in inspect container response");
-
-            return Ok(());
-        };
-
-        let status = match container_state {
-            ContainerStateStatusEnum::CREATED => PropertyStatus::Created,
-            ContainerStateStatusEnum::RUNNING | ContainerStateStatusEnum::RESTARTING => {
-                PropertyStatus::Running
-            }
-            ContainerStateStatusEnum::REMOVING => PropertyStatus::Received,
-            ContainerStateStatusEnum::EXITED | ContainerStateStatusEnum::DEAD => {
-                PropertyStatus::Stopped
-            }
-            ContainerStateStatusEnum::PAUSED | ContainerStateStatusEnum::EMPTY => {
-                debug!(%container_state, "ignoring state");
-
-                return Ok(());
-            }
-        };
-
-        AvailableContainer::new(&ctx.id)
-            .send(ctx.device, status)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/resource/container.rs
+++ b/edgehog-device-runtime-containers/src/resource/container.rs
@@ -16,7 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use bollard::secret::ContainerStateStatusEnum;
+use bollard::models::ContainerStateStatusEnum;
 use edgehog_store::models::containers::container::ContainerStatus;
 use tracing::{debug, warn};
 

--- a/edgehog-device-runtime-containers/src/resource/deployment.rs
+++ b/edgehog-device-runtime-containers/src/resource/deployment.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -85,7 +85,7 @@ impl<D> Resource<D> for Deployment
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableDeployment::new(&ctx.id)
             .send(ctx.device, PropertyStatus::Stopped)
             .await?;

--- a/edgehog-device-runtime-containers/src/resource/device_mapping.rs
+++ b/edgehog-device-runtime-containers/src/resource/device_mapping.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ impl<D> Resource<D> for DeviceMappingResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         // TODO: check for missing device
 
         AvailableDeviceMapping::new(&ctx.id)

--- a/edgehog-device-runtime-containers/src/resource/image.rs
+++ b/edgehog-device-runtime-containers/src/resource/image.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ use crate::{
     properties::{AvailableProp, Client, image::AvailableImage},
 };
 
-use super::{Context, Create, Resource, ResourceError, Result, State};
+use super::{Context, Create, Resource, Result, State};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ImageResource {
@@ -41,12 +41,14 @@ impl<D> Resource<D> for ImageResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableImage::new(&ctx.id).send(ctx.device, false).await?;
 
         ctx.store
             .update_image_status(ctx.id, ImageStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -56,26 +58,27 @@ impl<D> Create<D> for ImageResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let mut resource = ctx
-            .store
-            .find_image(ctx.id)
-            .await?
-            .ok_or(ResourceError::Missing {
-                id: ctx.id,
-                resource: "image",
-            })?;
+    const RESOURCE_NAME: &str = "image";
 
-        let exists = resource.image.inspect(ctx.client).await?.is_some();
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(mut resource) = ctx.store.find_image(ctx.id).await? else {
+            return Ok(None);
+        };
 
-        if exists {
+        let pulled = resource.image.inspect(ctx.client).await?.is_some();
+
+        AvailableImage::new(&ctx.id)
+            .send(ctx.device, pulled)
+            .await?;
+
+        if pulled {
             ctx.store
                 .update_image_local_id(ctx.id, resource.image.id.clone())
                 .await?;
 
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -118,22 +121,6 @@ where
         AvailableImage::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_image(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        let Some(mut resource) = ctx.store.find_image(ctx.id).await? else {
-            warn!("couldn't find image");
-
-            return Ok(());
-        };
-
-        let pulled = resource.image.inspect(ctx.client).await?.is_some();
-
-        AvailableImage::new(&ctx.id)
-            .send(ctx.device, pulled)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/resource/mod.rs
+++ b/edgehog-device-runtime-containers/src/resource/mod.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,7 @@
 
 use std::future::Future;
 
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -90,14 +90,19 @@ pub(crate) trait Resource<D>: Sized
 where
     D: Client + Sync + 'static,
 {
-    fn publish(ctx: Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
+    fn publish(ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
 }
 
 pub(crate) trait Create<D>: Resource<D>
 where
     D: Client + Send + Sync + 'static,
 {
-    fn fetch(ctx: &mut Context<'_, D>) -> impl Future<Output = Result<(State, Self)>> + Send;
+    const RESOURCE_NAME: &str;
+
+    /// Fetches and updates the state of the resource
+    fn fetch(
+        ctx: &mut Context<'_, D>,
+    ) -> impl Future<Output = Result<Option<(State, Self)>>> + Send;
 
     fn create(&mut self, ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
 
@@ -105,10 +110,21 @@ where
 
     fn unset(&mut self, ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
 
-    fn refresh(ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
+    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
+        if Self::fetch(ctx).await?.is_none() {
+            warn!("couldn't find {}", Self::RESOURCE_NAME);
+        }
+
+        Ok(())
+    }
 
     async fn up(mut ctx: Context<'_, D>) -> Result<Self> {
-        let (state, mut resource) = Self::fetch(&mut ctx).await?;
+        let (state, mut resource) = Self::fetch(&mut ctx).await.and_then(|opt| {
+            opt.ok_or(ResourceError::Missing {
+                id: ctx.id,
+                resource: Self::RESOURCE_NAME,
+            })
+        })?;
 
         match state {
             State::Missing => {
@@ -125,7 +141,12 @@ where
     }
 
     async fn down(mut ctx: Context<'_, D>) -> Result<()> {
-        let (state, mut resource) = Self::fetch(&mut ctx).await?;
+        let (state, mut resource) = Self::fetch(&mut ctx).await.and_then(|opt| {
+            opt.ok_or(ResourceError::Missing {
+                id: ctx.id,
+                resource: Self::RESOURCE_NAME,
+            })
+        })?;
 
         match state {
             State::Missing => {

--- a/edgehog-device-runtime-containers/src/resource/network.rs
+++ b/edgehog-device-runtime-containers/src/resource/network.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,14 +17,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use edgehog_store::models::containers::network::NetworkStatus;
-use tracing::warn;
 
 use crate::{
     network::Network,
     properties::{AvailableProp, Client, network::AvailableNetwork},
 };
 
-use super::{Context, Create, Resource, ResourceError, Result, State};
+use super::{Context, Create, Resource, Result, State};
 
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkResource {
@@ -41,7 +40,7 @@ impl<D> Resource<D> for NetworkResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableNetwork::new(&ctx.id)
             .send(ctx.device, false)
             .await?;
@@ -49,6 +48,8 @@ where
         ctx.store
             .update_network_status(ctx.id, NetworkStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -58,26 +59,27 @@ impl<D> Create<D> for NetworkResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let mut resource = ctx
-            .store
-            .find_network(ctx.id)
-            .await?
-            .ok_or(ResourceError::Missing {
-                id: ctx.id,
-                resource: "network",
-            })?;
+    const RESOURCE_NAME: &str = "network";
 
-        let exists = resource.network.inspect(ctx.client).await?.is_some();
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(mut resource) = ctx.store.find_network(ctx.id).await? else {
+            return Ok(None);
+        };
 
-        if exists {
+        let created = resource.network.inspect(ctx.client).await?.is_some();
+
+        AvailableNetwork::new(&ctx.id)
+            .send(ctx.device, created)
+            .await?;
+
+        if created {
             ctx.store
                 .update_network_local_id(ctx.id, resource.network.id.id.clone())
                 .await?;
 
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -109,22 +111,6 @@ where
         AvailableNetwork::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_network(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        let Some(mut resource) = ctx.store.find_network(ctx.id).await? else {
-            warn!("couldn't find network");
-
-            return Ok(());
-        };
-
-        let created = resource.network.inspect(ctx.client).await?.is_some();
-
-        AvailableNetwork::new(&ctx.id)
-            .send(ctx.device, created)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/resource/volume.rs
+++ b/edgehog-device-runtime-containers/src/resource/volume.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,14 +17,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use edgehog_store::models::containers::volume::VolumeStatus;
-use tracing::warn;
 
 use crate::{
     properties::{AvailableProp, Client, volume::AvailableVolume},
-    volume::{Volume, VolumeId},
+    volume::Volume,
 };
 
-use super::{Context, Create, Resource, ResourceError, Result, State};
+use super::{Context, Create, Resource, Result, State};
 
 #[derive(Debug, Clone)]
 pub(crate) struct VolumeResource {
@@ -41,7 +40,7 @@ impl<D> Resource<D> for VolumeResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableVolume::new(&ctx.id)
             .send(ctx.device, false)
             .await?;
@@ -49,6 +48,8 @@ where
         ctx.store
             .update_volume_status(ctx.id, VolumeStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -58,22 +59,23 @@ impl<D> Create<D> for VolumeResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let resource = ctx
-            .store
-            .find_volume(ctx.id)
-            .await?
-            .ok_or(ResourceError::Missing {
-                id: ctx.id,
-                resource: "volume",
-            })?;
+    const RESOURCE_NAME: &str = "voulume";
+
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(resource) = ctx.store.find_volume(ctx.id).await? else {
+            return Ok(None);
+        };
 
         let exists = resource.volume.inspect(ctx.client).await?.is_some();
 
+        AvailableVolume::new(&ctx.id)
+            .send(ctx.device, exists)
+            .await?;
+
         if exists {
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -99,24 +101,6 @@ where
         AvailableVolume::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_volume(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        if !ctx.store.check_volume_exists(ctx.id).await? {
-            warn!("couldn't find volume");
-
-            return Ok(());
-        };
-
-        let volume_id = VolumeId::new(ctx.id);
-
-        let created = volume_id.inspect(ctx.client).await?.is_some();
-
-        AvailableVolume::new(&ctx.id)
-            .send(ctx.device, created)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/service/mod.rs
+++ b/edgehog-device-runtime-containers/src/service/mod.rs
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -141,23 +141,33 @@ impl<D> Service<D> {
         D: Client + Send + Sync + 'static,
     {
         for id in self.store.load_images_to_publish().await? {
-            ImageResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            ImageResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_volumes_to_publish().await? {
-            VolumeResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            VolumeResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_networks_to_publish().await? {
-            NetworkResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            NetworkResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_device_mappings_to_publish().await? {
-            DeviceMappingResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            DeviceMappingResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_containers_to_publish().await? {
-            ContainerResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            ContainerResource::publish(&mut context).await?;
         }
 
         for id in self
@@ -165,7 +175,7 @@ impl<D> Service<D> {
             .load_deployments_in(DeploymentStatus::Received)
             .await?
         {
-            Deployment::publish(self.context(id)).await?;
+            Deployment::publish(&mut self.context(id)).await?;
         }
 
         Ok(())
@@ -277,14 +287,16 @@ impl<D> Service<D> {
         D: Client + Send + Sync + 'static,
     {
         let res = match id.resource_type() {
-            ResourceType::Image => ImageResource::publish(self.context(*id.uuid())).await,
-            ResourceType::Volume => VolumeResource::publish(self.context(*id.uuid())).await,
-            ResourceType::Network => NetworkResource::publish(self.context(*id.uuid())).await,
+            ResourceType::Image => ImageResource::publish(&mut self.context(*id.uuid())).await,
+            ResourceType::Volume => VolumeResource::publish(&mut self.context(*id.uuid())).await,
+            ResourceType::Network => NetworkResource::publish(&mut self.context(*id.uuid())).await,
             ResourceType::DeviceMapping => {
-                DeviceMappingResource::publish(self.context(*id.uuid())).await
+                DeviceMappingResource::publish(&mut self.context(*id.uuid())).await
             }
-            ResourceType::Container => ContainerResource::publish(self.context(*id.uuid())).await,
-            ResourceType::Deployment => Deployment::publish(self.context(*id.uuid())).await,
+            ResourceType::Container => {
+                ContainerResource::publish(&mut self.context(*id.uuid())).await
+            }
+            ResourceType::Deployment => Deployment::publish(&mut self.context(*id.uuid())).await,
         };
 
         if let Err(err) = res {
@@ -449,7 +461,13 @@ impl<D> Service<D> {
             debug!(%id, "stopping container");
 
             let mut ctx = self.context(id);
-            let (state, mut container) = ContainerResource::fetch(&mut ctx).await?;
+            let (state, mut container) =
+                ContainerResource::fetch(&mut ctx).await.and_then(|opt| {
+                    opt.ok_or(ResourceError::Missing {
+                        id: ctx.id,
+                        resource: "container",
+                    })
+                })?;
 
             match state {
                 State::Missing => {
@@ -775,6 +793,7 @@ mod tests {
     use crate::requests::image::tests::create_image_request_event;
     use crate::requests::network::tests::create_network_request_event;
     use crate::requests::volume::tests::create_volume_request_event;
+    use crate::tests::not_found_response;
     use crate::volume::{Volume, VolumeId};
     use crate::{docker, docker_mock};
 
@@ -803,14 +822,175 @@ mod tests {
         (service, handle)
     }
 
+    fn expect_image(
+        id: Uuid,
+        reference: &str,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        let image_path = format!("/{id}/pulled");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path.clone()),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_image()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(reference.to_string()))
+            .returning(|_| Err(not_found_response()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
+    fn expect_volume(
+        id: Uuid,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        let endpoint = format!("/{id}/created");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableVolumes"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_volume()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(id.to_string()))
+            .returning(|_| Err(not_found_response()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableVolumes"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
+    fn expect_network(
+        id: Uuid,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        let endpoint = format!("/{id}/created");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_network()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(id.to_string()), predicate::always())
+            .returning(|_, _| Err(not_found_response()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
+    fn expect_container(
+        id: Uuid,
+        device_mapping_id: Uuid,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableDeviceMappings"),
+                predicate::eq(format!("/{device_mapping_id}/present")),
+                predicate::eq(AstarteData::Boolean(true)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let endpoint = format!("/{id}/status");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_container()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(id.to_string()), predicate::always())
+            .returning(|_, _| Err(not_found_response()));
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
     #[tokio::test]
     async fn should_add_an_image() {
         let tmpdir = TempDir::new().unwrap();
 
         let id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
+        let reference = "docker.io/nginx:stable-alpine-slim";
 
-        let client = Docker::connect().await.unwrap();
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -820,21 +1000,10 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let image_path = format!("/{id}/pulled");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
-                predicate::eq(image_path),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_image(id, reference, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tmpdir, client, device).await;
 
-        let reference = "docker.io/nginx:stable-alpine-slim";
         let create_image_req = create_image_request_event(id, deployment_id, reference, "");
 
         let req = ContainerRequest::from_event(create_image_req).unwrap();
@@ -858,7 +1027,7 @@ mod tests {
         let id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
 
-        let client = Docker::connect().await.unwrap();
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -868,17 +1037,7 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let endpoint = format!("/{id}/created");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableVolumes"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_volume(id, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tempdir, client, device).await;
 
@@ -912,7 +1071,7 @@ mod tests {
         let id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
 
-        let client = Docker::connect().await.unwrap();
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -922,17 +1081,7 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let endpoint = format!("/{id}/created");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_network(id, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tempdir, client, device).await;
 
@@ -968,7 +1117,9 @@ mod tests {
         let device_mapping_id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
 
-        let client = Docker::connect().await.unwrap();
+        let reference = "docker.io/nginx:stable-alpine-slim";
+
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -978,57 +1129,13 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let image_path = format!("/{image_id}/pulled");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
-                predicate::eq(image_path),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
-
-        let endpoint = format!("/{network_id}/created");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
-
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableDeviceMappings"),
-                predicate::eq(format!("/{device_mapping_id}/present")),
-                predicate::eq(AstarteData::Boolean(true)),
-            )
-            .returning(|_, _, _| Ok(()));
-
-        let endpoint = format!("/{id}/status");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::from("Received")),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_image(image_id, reference, &mut seq, &mut device, &mut client);
+        expect_network(network_id, &mut seq, &mut device, &mut client);
+        expect_container(id, device_mapping_id, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tempdir, client, device).await;
 
-        // Image
-        let reference = "docker.io/nginx:stable-alpine-slim";
+        // image
         let create_image_req = create_image_request_event(image_id, deployment_id, reference, "");
 
         let req = ContainerRequest::from_event(create_image_req).unwrap();
@@ -1139,6 +1246,19 @@ mod tests {
                 .in_sequence(&mut seq)
                 .returning(|_| Err(not_found_response()));
 
+            let container_name = container_id.to_string();
+            mock.expect_inspect_container()
+                .times(1)
+                .in_sequence(&mut seq)
+                .with(predicate::eq(container_name.clone()), predicate::always())
+                .returning(|_, _| Err(docker::tests::not_found_response()));
+
+            mock.expect_inspect_image()
+                .withf(move |name| name == reference)
+                .once()
+                .in_sequence(&mut seq)
+                .returning(|_| Err(not_found_response()));
+
             mock.expect_create_image()
                 .with(
                     predicate::eq(Some(CreateImageOptions {
@@ -1165,11 +1285,10 @@ mod tests {
                 })
                 });
 
-            let container_name = container_id.to_string();
             mock.expect_inspect_container()
-                .withf(move |name, _option| name == container_name)
-                .once()
+                .times(1)
                 .in_sequence(&mut seq)
+                .with(predicate::eq(container_name), predicate::always())
                 .returning(|_, _| Err(docker::tests::not_found_response()));
 
             let name_exp = container_id.to_string();
@@ -1213,7 +1332,7 @@ mod tests {
         let image_path = format!("/{image_id}/pulled");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
@@ -1225,7 +1344,7 @@ mod tests {
         let endpoint = format!("/{container_id}/status");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
@@ -1270,11 +1389,23 @@ mod tests {
             .expect_set_property()
             .once()
             .in_sequence(&mut seq)
-            .withf(move |interface, path, value| {
-                interface == "io.edgehog.devicemanager.apps.AvailableImages"
-                    && path == (image_path)
-                    && *value == AstarteData::Boolean(true)
-            })
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let image_path = format!("/{image_id}/pulled");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(true)),
+            )
             .returning(|_, _, _| Ok(()));
 
         let endpoint = format!("/{container_id}/status");
@@ -1282,11 +1413,22 @@ mod tests {
             .expect_set_property()
             .once()
             .in_sequence(&mut seq)
-            .withf(move |interface, path, value| {
-                interface == "io.edgehog.devicemanager.apps.AvailableContainers"
-                    && path == endpoint
-                    && *value == ContainerStatus::Created.to_string()
-            })
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::String(ContainerStatus::Created.to_string())),
+            )
             .returning(|_, _, _| Ok(()));
 
         let endpoint = format!("/{container_id}/status");
@@ -1392,10 +1534,16 @@ mod tests {
             let mut mock = docker::Client::new();
             let mut seq = mockall::Sequence::new();
 
+            mock.expect_inspect_image()
+                .withf(move |name| name == reference)
+                .once()
+                .in_sequence(&mut seq)
+                .returning(|_| Err(not_found_response()));
+
             let container_name = container_id.to_string();
             mock.expect_inspect_container()
                 .withf(move |name, _option| name == container_name)
-                .once()
+                .times(2)
                 .in_sequence(&mut seq)
                 .returning(|_, _| Err(docker::tests::not_found_response()));
 
@@ -1419,7 +1567,7 @@ mod tests {
         let image_path = format!("/{image_id}/pulled");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
@@ -1431,7 +1579,7 @@ mod tests {
         let endpoint = format!("/{container_id}/status");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
@@ -1473,6 +1621,18 @@ mod tests {
 
         let endpoint = format!("/{container_id}/status");
         device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let endpoint = format!("/{container_id}/status");
+        device
             .expect_unset_property()
             .once()
             .in_sequence(&mut seq)
@@ -1481,6 +1641,18 @@ mod tests {
                 predicate::eq(endpoint),
             )
             .returning(|_, _| Ok(()));
+
+        let image_path = format!("/{image_id}/pulled");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
 
         let image_path = format!("/{image_id}/pulled");
         device

--- a/edgehog-device-runtime-containers/src/stats/blkio.rs
+++ b/edgehog-device-runtime-containers/src/stats/blkio.rs
@@ -1,6 +1,6 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 //! Container and volume storage stats.
 
 use astarte_device_sdk::IntoAstarteObject;
-use bollard::secret::{ContainerBlkioStatEntry, ContainerBlkioStats};
+use bollard::models::{ContainerBlkioStatEntry, ContainerBlkioStats};
 
 use super::{IntoAstarteExt, Metric};
 
@@ -96,7 +96,7 @@ mod tests {
     use astarte_device_sdk::store::SqliteStore;
     use astarte_device_sdk::transport::mqtt::Mqtt;
     use astarte_device_sdk_mock::MockDeviceClient;
-    use bollard::secret::{ContainerBlkioStatEntry, ContainerBlkioStats};
+    use bollard::models::{ContainerBlkioStatEntry, ContainerBlkioStats};
     use mockall::predicate;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;

--- a/edgehog-device-runtime-containers/src/stats/cpu.rs
+++ b/edgehog-device-runtime-containers/src/stats/cpu.rs
@@ -1,6 +1,6 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 //! Container cpu statistics
 
 use astarte_device_sdk::IntoAstarteObject;
-use bollard::secret::ContainerCpuStats;
+use bollard::models::ContainerCpuStats;
 
 use super::{IntoAstarteExt, Metric};
 

--- a/edgehog-device-runtime-containers/src/stats/mod.rs
+++ b/edgehog-device-runtime-containers/src/stats/mod.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use astarte_device_sdk::Client;
 use astarte_device_sdk::aggregate::AstarteObject;
 use astarte_device_sdk::chrono::{DateTime, Utc};
-use bollard::secret::ContainerStatsResponse;
+use bollard::models::ContainerStatsResponse;
 use edgehog_store::models::containers::container::ContainerStatus;
 use edgehog_store::models::containers::volume::VolumeStatus;
 use tokio::sync::OnceCell;

--- a/edgehog-device-runtime-service/src/service/containers/v1/conv.rs
+++ b/edgehog-device-runtime-service/src/service/containers/v1/conv.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,11 +22,9 @@ use std::result::Result;
 use edgehog_containers::bollard;
 use edgehog_containers::bollard::models::{
     ContainerBlkioStatEntry, ContainerBlkioStats, ContainerCpuStats, ContainerCpuUsage,
-    ContainerMemoryStats, ContainerNetworkStats, ContainerStateStatusEnum,
-    ContainerSummaryStateEnum, ContainerThrottlingData, PortBinding,
-};
-use edgehog_containers::bollard::secret::{
-    ContainerInspectResponse, ContainerStatsResponse, PortSummaryTypeEnum,
+    ContainerInspectResponse, ContainerMemoryStats, ContainerNetworkStats,
+    ContainerStateStatusEnum, ContainerStatsResponse, ContainerSummaryStateEnum,
+    ContainerThrottlingData, PortBinding, PortSummaryTypeEnum,
 };
 use edgehog_proto::containers::v1::{
     BlkioStats, BlkioValue, Container, ContainerId, ContainerState, ContainerSummary, CpuStats,


### PR DESCRIPTION
Move the refrecsh logic into the fetch method to update the resources status when we start a deployment.