### PR TITLE
fix(securityEvents): attach container names as event fields

### DIFF
--- a/edgehog-device-runtime-containers/src/docker/container.rs
+++ b/edgehog-device-runtime-containers/src/docker/container.rs
@@ -48,6 +48,7 @@ use crate::{
         container::{parse_port_binding, RestartPolicy},
         BindingError,
     },
+    tracing::{container_event, ContainerSecurityEvent},
 };
 
 /// Error for the container operations.
@@ -221,21 +222,32 @@ impl ContainerId {
     pub(crate) async fn start(&self, client: &Client) -> Result<Option<()>, ContainerError> {
         debug!("starting {self}");
 
+        let container_name = self.name_as_str();
+        container_event(ContainerSecurityEvent::ContainerStartInit, container_name);
+
         let res = client
             .start_container(self.container(), None::<StartContainerOptions>)
             .await;
 
         match res {
-            Ok(()) => Ok(Some(())),
+            Ok(()) => {
+                container_event(ContainerSecurityEvent::ContainerStartOk, container_name);
+
+                Ok(Some(()))
+            }
             Err(BollardError::DockerResponseServerError {
                 status_code: 404,
                 message,
             }) => {
+                container_event(ContainerSecurityEvent::ContainerStartFail, container_name);
                 warn!("container not found: {message}");
 
                 Ok(None)
             }
-            Err(err) => return Err(ContainerError::Start(err)),
+            Err(err) => {
+                container_event(ContainerSecurityEvent::ContainerStartFail, container_name);
+                Err(ContainerError::Start(err))
+            }
         }
     }
 
@@ -246,16 +258,24 @@ impl ContainerId {
     pub(crate) async fn stop(&self, client: &Client) -> Result<Option<()>, ContainerError> {
         debug!("stopping {self}");
 
+        let container_name = self.name_as_str();
+        container_event(ContainerSecurityEvent::ContainerStopInit, container_name);
+
         let res = client
             .stop_container(self.container(), None::<StopContainerOptions>)
             .await;
 
         match res {
-            Ok(()) => Ok(Some(())),
+            Ok(()) => {
+                container_event(ContainerSecurityEvent::ContainerStopOk, container_name);
+
+                Ok(Some(()))
+            }
             Err(BollardError::DockerResponseServerError {
                 status_code: 304,
                 message,
             }) => {
+                container_event(ContainerSecurityEvent::ContainerStopOk, container_name);
                 debug!("container already stopped: {message}");
 
                 Ok(Some(()))
@@ -264,11 +284,15 @@ impl ContainerId {
                 status_code: 404,
                 message,
             }) => {
+                container_event(ContainerSecurityEvent::ContainerStopFail, container_name);
                 warn!("container not found: {message}");
 
                 Ok(None)
             }
-            Err(err) => return Err(ContainerError::Start(err)),
+            Err(err) => {
+                container_event(ContainerSecurityEvent::ContainerStopFail, container_name);
+                Err(ContainerError::Start(err))
+            }
         }
     }
 

--- a/edgehog-device-runtime-containers/src/service/mod.rs
+++ b/edgehog-device-runtime-containers/src/service/mod.rs
@@ -23,7 +23,7 @@ use std::fmt::{Debug, Display};
 use astarte_device_sdk::event::FromEventError;
 use edgehog_store::{conversions::SqlUuid, models::containers::deployment::DeploymentStatus};
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn, Instrument};
 use uuid::Uuid;
 
 use crate::{
@@ -303,14 +303,20 @@ impl<D> Service<D> {
     where
         D: Client + Send + Sync + 'static,
     {
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentInit);
+        crate::tracing::deployment_event(
+            crate::tracing::DeploymentSecurityEvent::ContainerDeploymentInit,
+            id,
+        );
 
         let deployment = match self.store.find_complete_deployment(id).await {
             Ok(Some(deployment)) => deployment,
             Ok(None) => {
                 error!("{id} not found");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                    id,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, format!("{id} not found"))
                     .send(&id, &mut self.device)
@@ -323,7 +329,10 @@ impl<D> Service<D> {
 
                 error!(error = err, "couldn't start deployment");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                    id,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, err)
                     .send(&id, &mut self.device)
@@ -339,22 +348,31 @@ impl<D> Service<D> {
             .send(&id, &mut self.device)
             .await;
 
-        if let Err(err) = self.start_deployment(id, deployment).await {
-            let err = format!("{:#}", eyre::Report::new(err));
+        if let Err(error) = self
+            .start_deployment(id, deployment)
+            .instrument(crate::tracing::deployment_span(id))
+            .await
+        {
+            let error = format!("{:#}", eyre::Report::new(error));
 
-            error!(error = err, "couldn't start deployment");
+            error!(error, "couldn't start deployment");
 
-            crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStartFail);
-            crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+            crate::tracing::deployment_event(
+                crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                id,
+            );
 
-            DeploymentEvent::new(EventStatus::Error, err)
+            DeploymentEvent::new(EventStatus::Error, error)
                 .send(&id, &mut self.device)
                 .await;
 
             return;
         }
 
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentOk);
+        crate::tracing::deployment_event(
+            crate::tracing::DeploymentSecurityEvent::ContainerDeploymentOk,
+            id,
+        );
 
         DeploymentEvent::new(EventStatus::Started, "")
             .send(&id, &mut self.device)
@@ -367,8 +385,6 @@ impl<D> Service<D> {
     where
         D: Client + Send + Sync + 'static,
     {
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStartInit);
-
         for id in deployment.images {
             ImageResource::up(self.context(id)).await?;
         }
@@ -394,8 +410,6 @@ impl<D> Service<D> {
             )
             .await
             .map_err(ResourceError::Property)?;
-
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStartOk);
 
         Ok(())
     }
@@ -436,14 +450,16 @@ impl<D> Service<D> {
             .send(&id, &mut self.device)
             .await;
 
-        if let Err(err) = self.stop_deployment(id, &containers).await {
-            let err = format!("{:#}", eyre::Report::new(err));
+        if let Err(error) = self
+            .stop_deployment(id, &containers)
+            .instrument(crate::tracing::deployment_span(id))
+            .await
+        {
+            let error = format!("{:#}", eyre::Report::new(error));
 
-            error!(error = err, "couldn't stop deployment");
+            error!(error, "couldn't stop deployment");
 
-            crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStopFail);
-
-            DeploymentEvent::new(EventStatus::Error, err)
+            DeploymentEvent::new(EventStatus::Error, error)
                 .send(&id, &mut self.device)
                 .await;
 
@@ -462,8 +478,6 @@ impl<D> Service<D> {
     where
         D: Client + Send + Sync + 'static,
     {
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStopInit);
-
         for id in containers {
             debug!(%id, "stopping container");
 
@@ -490,8 +504,6 @@ impl<D> Service<D> {
             .await
             .map_err(ResourceError::from)?;
 
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStopOk);
-
         Ok(())
     }
 
@@ -501,14 +513,20 @@ impl<D> Service<D> {
     where
         D: Client + Send + Sync + 'static,
     {
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerUndeploymentInit);
+        crate::tracing::deployment_event(
+            crate::tracing::DeploymentSecurityEvent::ContainerUndeploymentInit,
+            id,
+        );
 
         let deployment = match self.store.find_deployment_for_delete(id).await {
             Ok(Some(deployment)) => deployment,
             Ok(None) => {
                 error!("{id} not found");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerUndeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerUndeploymentFail,
+                    id,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, format!("{id} not found"))
                     .send(&id, &mut self.device)
@@ -521,7 +539,10 @@ impl<D> Service<D> {
 
                 error!(error = err, "couldn't delete deployment");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerUndeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerUndeploymentFail,
+                    id,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, err)
                     .send(&id, &mut self.device)
@@ -537,21 +558,31 @@ impl<D> Service<D> {
             .send(&id, &mut self.device)
             .await;
 
-        if let Err(err) = self.delete_deployment(id, deployment).await {
-            let err = format!("{:#}", eyre::Report::new(err));
+        if let Err(error) = self
+            .delete_deployment(id, deployment)
+            .instrument(crate::tracing::deployment_span(id))
+            .await
+        {
+            let error = format!("{:#}", eyre::Report::new(error));
 
-            error!(error = err, "couldn't delete deployment");
+            error!(error, "couldn't delete deployment");
 
-            crate::tracing::notify(crate::tracing::SecurityEvent::ContainerUndeploymentFail);
+            crate::tracing::deployment_event(
+                crate::tracing::DeploymentSecurityEvent::ContainerUndeploymentFail,
+                id,
+            );
 
-            DeploymentEvent::new(EventStatus::Error, err)
+            DeploymentEvent::new(EventStatus::Error, error)
                 .send(&id, &mut self.device)
                 .await;
 
             return;
         }
 
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerUndeploymentOk);
+        crate::tracing::deployment_event(
+            crate::tracing::DeploymentSecurityEvent::ContainerUndeploymentOk,
+            id,
+        );
 
         info!("deployment deleted");
     }
@@ -597,7 +628,10 @@ impl<D> Service<D> {
     where
         D: Client + Send + Sync + 'static,
     {
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentInit);
+        crate::tracing::deployment_event(
+            crate::tracing::DeploymentSecurityEvent::ContainerDeploymentInit,
+            bundle.to,
+        );
 
         let from_deployment = match self
             .store
@@ -609,7 +643,10 @@ impl<D> Service<D> {
                 let msg = format!("{} not found", bundle.from);
                 error!("{msg}");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                    bundle.to,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, msg)
                     .send(&bundle.from, &mut self.device)
@@ -622,7 +659,10 @@ impl<D> Service<D> {
 
                 error!(error = err, "couldn't update deployment");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                    bundle.to,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, err)
                     .send(&bundle.from, &mut self.device)
@@ -638,7 +678,10 @@ impl<D> Service<D> {
                 let msg = format!("{} not found", bundle.to);
                 error!("{msg}");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                    bundle.to,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, msg)
                     .send(&bundle.to, &mut self.device)
@@ -651,7 +694,10 @@ impl<D> Service<D> {
 
                 error!(error = err, "couldn't update deployment");
 
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+                crate::tracing::deployment_event(
+                    crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                    bundle.to,
+                );
 
                 DeploymentEvent::new(EventStatus::Error, err)
                     .send(&bundle.to, &mut self.device)
@@ -676,7 +722,10 @@ impl<D> Service<D> {
 
             error!(error = err, "couldn't update deployment");
 
-            crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentFail);
+            crate::tracing::deployment_event(
+                crate::tracing::DeploymentSecurityEvent::ContainerDeploymentFail,
+                bundle.to,
+            );
 
             DeploymentEvent::new(EventStatus::Error, err)
                 .send(&bundle.from, &mut self.device)
@@ -690,7 +739,10 @@ impl<D> Service<D> {
             return;
         }
 
-        crate::tracing::notify(crate::tracing::SecurityEvent::ContainerDeploymentOk);
+        crate::tracing::deployment_event(
+            crate::tracing::DeploymentSecurityEvent::ContainerDeploymentOk,
+            bundle.to,
+        );
 
         info!("deployment updated");
     }
@@ -705,16 +757,12 @@ impl<D> Service<D> {
         D: Client + Send + Sync + 'static,
     {
         self.stop_deployment(bundle.from, to_stop)
-            .await
-            .inspect_err(|_| {
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStartFail)
-            })?;
+            .instrument(crate::tracing::deployment_span(bundle.from))
+            .await?;
 
         self.start_deployment(bundle.to, to_start)
-            .await
-            .inspect_err(|_| {
-                crate::tracing::notify(crate::tracing::SecurityEvent::ContainerStartFail)
-            })?;
+            .instrument(crate::tracing::deployment_span(bundle.to))
+            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/tracing.rs
+++ b/edgehog-device-runtime-containers/src/tracing.rs
@@ -21,11 +21,12 @@
 //! This module provides structured auditing and logging for system container lifecycle
 
 use tracing::Level;
+use uuid::Uuid;
 
 /// Represents a security device event.
 #[repr(u16)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SecurityEvent {
+pub enum DeploymentSecurityEvent {
     /// Indicates that a container deployment process has been initialized.
     ContainerDeploymentInit = 0,
     /// Indicates that a container deployment process completed successfully.
@@ -38,6 +39,33 @@ pub enum SecurityEvent {
     ContainerUndeploymentOk = 4,
     /// Indicates that a container undeployment (removal) process failed to complete.
     ContainerUndeploymentFail = 5,
+}
+
+impl DeploymentSecurityEvent {
+    /// Returns the original string description for the device event.
+    fn description(&self) -> &'static str {
+        match self {
+            Self::ContainerDeploymentInit => "Container deployment started",
+            Self::ContainerDeploymentOk => "Container deployment success",
+            Self::ContainerDeploymentFail => "Container deployment failure",
+            Self::ContainerUndeploymentInit => "Container undeployment started",
+            Self::ContainerUndeploymentOk => "Container undeployment success",
+            Self::ContainerUndeploymentFail => "Container undeployment failure",
+        }
+    }
+
+    fn level(&self) -> Level {
+        match self {
+            Self::ContainerDeploymentFail | Self::ContainerUndeploymentFail => Level::ERROR,
+            _ => Level::INFO,
+        }
+    }
+}
+
+/// Represents a security device event.
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerSecurityEvent {
     /// Indicates that an offline or idle container is currently starting up.
     ContainerStartInit = 6,
     /// Indicates that a container successfully transitioned to a running state.
@@ -52,16 +80,10 @@ pub enum SecurityEvent {
     ContainerStopFail = 11,
 }
 
-impl SecurityEvent {
+impl ContainerSecurityEvent {
     /// Returns the original string description for the device event.
     fn description(&self) -> &'static str {
         match self {
-            Self::ContainerDeploymentInit => "Container deployment started",
-            Self::ContainerDeploymentOk => "Container deployment success",
-            Self::ContainerDeploymentFail => "Container deployment failure",
-            Self::ContainerUndeploymentInit => "Container undeployment started",
-            Self::ContainerUndeploymentOk => "Container undeployment success",
-            Self::ContainerUndeploymentFail => "Container undeployment failure",
             Self::ContainerStartInit => "Container starting",
             Self::ContainerStartOk => "Container started successfully",
             Self::ContainerStartFail => "Container failed to start",
@@ -73,11 +95,43 @@ impl SecurityEvent {
 
     fn level(&self) -> Level {
         match self {
-            Self::ContainerDeploymentFail
-            | Self::ContainerUndeploymentFail
-            | Self::ContainerStartFail
-            | Self::ContainerStopFail => Level::ERROR,
+            Self::ContainerStartFail | Self::ContainerStopFail => Level::ERROR,
             _ => Level::INFO,
+        }
+    }
+}
+
+/// This function returns a span guard that should be used to instrument container events.
+pub fn deployment_span(deployment_id: Uuid) -> tracing::Span {
+    tracing::span!(target:"edgehog-security-event", Level::INFO, "deployment_event", %deployment_id)
+}
+
+/// Logs a structured security event to the specialized `"edgehog-security-event"` target.
+///
+/// # Structured Fields
+/// Logs emitted by this function include the following key-value pairs for structured log collectors:
+/// * `target`: Always explicitly set to `"edgehog-security-event"`.
+/// * `id`: The `u16` numeric discriminant representing the specific security event type.
+/// * `message`: The human-readable static string description of the event.
+pub fn deployment_event(event: DeploymentSecurityEvent, deployment_id: Uuid) {
+    let id = event as u16;
+    let message = event.description();
+
+    match event.level() {
+        Level::ERROR => {
+            tracing::error!(target:"edgehog-security-event", %deployment_id, id, "{message}")
+        }
+        Level::WARN => {
+            tracing::warn!(target:"edgehog-security-event", %deployment_id, id, "{message}")
+        }
+        Level::INFO => {
+            tracing::info!(target:"edgehog-security-event", %deployment_id, id, "{message}")
+        }
+        Level::DEBUG => {
+            tracing::debug!(target:"edgehog-security-event", %deployment_id, id, "{message}")
+        }
+        Level::TRACE => {
+            tracing::trace!(target:"edgehog-security-event", %deployment_id, id, "{message}")
         }
     }
 }
@@ -89,15 +143,26 @@ impl SecurityEvent {
 /// * `target`: Always explicitly set to `"edgehog-security-event"`.
 /// * `id`: The `u16` numeric discriminant representing the specific security event type.
 /// * `message`: The human-readable static string description of the event.
-pub fn notify(event: SecurityEvent) {
+/// * `container_name`: The name of the container that relates to the event logged
+pub fn container_event(event: ContainerSecurityEvent, container_name: &str) {
     let id = event as u16;
     let message = event.description();
 
     match event.level() {
-        Level::ERROR => tracing::error!(target:"edgehog-security-event", id, "{message}"),
-        Level::WARN => tracing::warn!(target:"edgehog-security-event", id, "{message}"),
-        Level::INFO => tracing::info!(target:"edgehog-security-event", id, "{message}"),
-        Level::DEBUG => tracing::debug!(target:"edgehog-security-event", id, "{message}"),
-        Level::TRACE => tracing::trace!(target:"edgehog-security-event", id, "{message}"),
+        Level::ERROR => {
+            tracing::error!(target:"edgehog-security-event", id, container_name, "{message}")
+        }
+        Level::WARN => {
+            tracing::warn!(target:"edgehog-security-event", id, container_name, "{message}")
+        }
+        Level::INFO => {
+            tracing::info!(target:"edgehog-security-event", id, container_name, "{message}")
+        }
+        Level::DEBUG => {
+            tracing::debug!(target:"edgehog-security-event", id, container_name, "{message}")
+        }
+        Level::TRACE => {
+            tracing::trace!(target:"edgehog-security-event", id, container_name, "{message}")
+        }
     }
 }

--- a/edgehog-device-runtime-service/src/service/containers/v1/mod.rs
+++ b/edgehog-device-runtime-service/src/service/containers/v1/mod.rs
@@ -158,31 +158,15 @@ impl ContainersService for EdgehogService {
         let inner = request.into_inner();
         let id = parse_id(&inner.id)?;
 
-        edgehog_containers::tracing::notify(
-            edgehog_containers::tracing::SecurityEvent::ContainerStartInit,
-        );
-
         let started = self.container_handle()?.start(id).await.map_err(|err| {
             error!(error = format!("{err:#}"), "couldn't start the container");
-
-            edgehog_containers::tracing::notify(
-                edgehog_containers::tracing::SecurityEvent::ContainerStartFail,
-            );
 
             Status::internal("couldn't start the container")
         })?;
 
         if started.is_none() {
-            edgehog_containers::tracing::notify(
-                edgehog_containers::tracing::SecurityEvent::ContainerStartFail,
-            );
-
             return Err(Status::not_found("container doesn't exist"));
         }
-
-        edgehog_containers::tracing::notify(
-            edgehog_containers::tracing::SecurityEvent::ContainerStartOk,
-        );
 
         Ok(Response::new(()))
     }
@@ -194,31 +178,15 @@ impl ContainersService for EdgehogService {
         let inner = request.into_inner();
         let id = parse_id(&inner.id)?;
 
-        edgehog_containers::tracing::notify(
-            edgehog_containers::tracing::SecurityEvent::ContainerStopInit,
-        );
-
         let started = self.container_handle()?.stop(id).await.map_err(|err| {
             error!(error = format!("{err:#}"), "couldn't stop the container");
-
-            edgehog_containers::tracing::notify(
-                edgehog_containers::tracing::SecurityEvent::ContainerStopFail,
-            );
 
             Status::internal("couldn't stop the container")
         })?;
 
         if started.is_none() {
-            edgehog_containers::tracing::notify(
-                edgehog_containers::tracing::SecurityEvent::ContainerStopFail,
-            );
-
             return Err(Status::not_found("container doesn't exist"));
         }
-
-        edgehog_containers::tracing::notify(
-            edgehog_containers::tracing::SecurityEvent::ContainerStopOk,
-        );
 
         Ok(Response::new(()))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,8 +179,7 @@ fn init_tracing() -> eyre::Result<()> {
             .with_syslog_identifier("edgehog_runtime_security_events".to_string())
             .with_filter(
                 tracing_subscriber::filter::Targets::new()
-                    .with_target("edgehog-security-event", tracing::Level::TRACE)
-                    .with_target("security-event", tracing::Level::TRACE),
+                    .with_target("edgehog-security-event", tracing::Level::TRACE),
             ),
     );
 


### PR DESCRIPTION
The container events start/stop in all variants (init/fail/ok) now include `F_CONTAINER_NAME` field that indentifies the container.
When the event is related to a deployment the field `F_DEPLOYMENT_ID` will identify the edgehog deployment.