### PR TITLE
fix(containers): update properties when fetching the resources

### DIFF
--- a/edgehog-device-runtime-containers/src/docker/image.rs
+++ b/edgehog-device-runtime-containers/src/docker/image.rs
@@ -274,7 +274,15 @@ impl Image {
         debug!("removing {self}");
 
         let res = client
-            .remove_image(id, None::<RemoveImageOptions>, self.docker_credentials()?)
+            .remove_image(
+                id,
+                // NOTE: remove image by id with multiple tags
+                Some(RemoveImageOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+                self.docker_credentials()?,
+            )
             .await;
 
         match res {
@@ -578,7 +586,10 @@ mod tests {
             mock.expect_remove_image()
                 .with(
                     predicate::eq(name.to_string()),
-                    predicate::eq(None),
+                    predicate::eq(Some(RemoveImageOptions {
+                        force: true,
+                        ..Default::default()
+                    })),
                     predicate::eq(None),
                 )
                 .once()

--- a/edgehog-device-runtime-containers/src/resource/container.rs
+++ b/edgehog-device-runtime-containers/src/resource/container.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -100,6 +100,49 @@ impl ContainerResource {
 
         Ok(())
     }
+
+    async fn update_status<D>(&mut self, ctx: &mut Context<'_, D>) -> Result<bool>
+    where
+        D: Client + Send + Sync + 'static,
+    {
+        let Some(inspect) = self.container.inspect(ctx.client).await? else {
+            debug!("container deleted");
+
+            AvailableContainer::new(&ctx.id)
+                .send(ctx.device, PropertyStatus::Received)
+                .await?;
+
+            return Ok(false);
+        };
+
+        let Some(container_state) = inspect.state.and_then(|state| state.status) else {
+            warn!("couldn't find status in inspect container response");
+
+            return Ok(false);
+        };
+
+        let (status, exists) = match container_state {
+            ContainerStateStatusEnum::CREATED => (PropertyStatus::Created, true),
+            ContainerStateStatusEnum::RUNNING | ContainerStateStatusEnum::RESTARTING => {
+                (PropertyStatus::Running, true)
+            }
+            ContainerStateStatusEnum::REMOVING => (PropertyStatus::Received, false),
+            ContainerStateStatusEnum::EXITED | ContainerStateStatusEnum::DEAD => {
+                (PropertyStatus::Stopped, true)
+            }
+            ContainerStateStatusEnum::PAUSED | ContainerStateStatusEnum::EMPTY => {
+                debug!(%container_state, "weird state");
+
+                (PropertyStatus::Created, true)
+            }
+        };
+
+        AvailableContainer::new(&ctx.id)
+            .send(ctx.device, status)
+            .await?;
+
+        Ok(exists)
+    }
 }
 
 #[async_trait]
@@ -107,7 +150,7 @@ impl<D> Resource<D> for ContainerResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableContainer::new(&ctx.id)
             .send(ctx.device, PropertyStatus::Received)
             .await?;
@@ -115,6 +158,8 @@ where
         ctx.store
             .update_container_status(ctx.id, ContainerStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -124,27 +169,25 @@ impl<D> Create<D> for ContainerResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let mut container =
-            ctx.store
-                .find_container(ctx.id)
-                .await?
-                .ok_or(ResourceError::Missing {
-                    id: ctx.id,
-                    resource: "container",
-                })?;
+    const RESOURCE_NAME: &'static str = "container";
 
-        let exists = container.inspect(ctx.client).await?.is_some();
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(container) = ctx.store.find_container(ctx.id).await? else {
+            return Ok(None);
+        };
 
-        let resource = ContainerResource::new(container);
+        let mut resource = ContainerResource::new(container);
+
+        let exists = resource.update_status(ctx).await?;
+
         if exists {
             ctx.store
                 .update_container_local_id(ctx.id, resource.container.id.id.clone())
                 .await?;
 
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -178,52 +221,6 @@ where
         AvailableContainer::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_container(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        let Some(mut container) = ctx.store.find_container(ctx.id).await? else {
-            warn!("couldn't find container");
-
-            return Ok(());
-        };
-
-        let Some(inspect) = container.inspect(ctx.client).await? else {
-            debug!("container deleted");
-
-            AvailableContainer::new(&ctx.id)
-                .send(ctx.device, PropertyStatus::Received)
-                .await?;
-
-            return Ok(());
-        };
-
-        let Some(container_state) = inspect.state.and_then(|state| state.status) else {
-            warn!("couldn't find status in inspect container response");
-
-            return Ok(());
-        };
-
-        let status = match container_state {
-            ContainerStateStatusEnum::CREATED => PropertyStatus::Created,
-            ContainerStateStatusEnum::RUNNING | ContainerStateStatusEnum::RESTARTING => {
-                PropertyStatus::Running
-            }
-            ContainerStateStatusEnum::REMOVING => PropertyStatus::Received,
-            ContainerStateStatusEnum::EXITED | ContainerStateStatusEnum::DEAD => {
-                PropertyStatus::Stopped
-            }
-            ContainerStateStatusEnum::PAUSED | ContainerStateStatusEnum::EMPTY => {
-                debug!(%container_state, "ignoring state");
-
-                return Ok(());
-            }
-        };
-
-        AvailableContainer::new(&ctx.id)
-            .send(ctx.device, status)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/resource/deployment.rs
+++ b/edgehog-device-runtime-containers/src/resource/deployment.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -88,7 +88,7 @@ impl<D> Resource<D> for Deployment
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableDeployment::new(&ctx.id)
             .send(ctx.device, PropertyStatus::Stopped)
             .await?;

--- a/edgehog-device-runtime-containers/src/resource/device_mapping.rs
+++ b/edgehog-device-runtime-containers/src/resource/device_mapping.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ impl<D> Resource<D> for DeviceMappingResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         // TODO: check for missing device
 
         AvailableDeviceMapping::new(&ctx.id)

--- a/edgehog-device-runtime-containers/src/resource/image.rs
+++ b/edgehog-device-runtime-containers/src/resource/image.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,7 @@ use crate::{
     properties::{image::AvailableImage, AvailableProp, Client},
 };
 
-use super::{Context, Create, Resource, ResourceError, Result, State};
+use super::{Context, Create, Resource, Result, State};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ImageResource {
@@ -43,12 +43,14 @@ impl<D> Resource<D> for ImageResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableImage::new(&ctx.id).send(ctx.device, false).await?;
 
         ctx.store
             .update_image_status(ctx.id, ImageStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -58,26 +60,27 @@ impl<D> Create<D> for ImageResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let mut resource = ctx
-            .store
-            .find_image(ctx.id)
-            .await?
-            .ok_or(ResourceError::Missing {
-                id: ctx.id,
-                resource: "image",
-            })?;
+    const RESOURCE_NAME: &'static str = "image";
 
-        let exists = resource.image.inspect(ctx.client).await?.is_some();
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(mut resource) = ctx.store.find_image(ctx.id).await? else {
+            return Ok(None);
+        };
 
-        if exists {
+        let pulled = resource.image.inspect(ctx.client).await?.is_some();
+
+        AvailableImage::new(&ctx.id)
+            .send(ctx.device, pulled)
+            .await?;
+
+        if pulled {
             ctx.store
                 .update_image_local_id(ctx.id, resource.image.id.clone())
                 .await?;
 
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -120,22 +123,6 @@ where
         AvailableImage::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_image(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        let Some(mut resource) = ctx.store.find_image(ctx.id).await? else {
-            warn!("couldn't find image");
-
-            return Ok(());
-        };
-
-        let pulled = resource.image.inspect(ctx.client).await?.is_some();
-
-        AvailableImage::new(&ctx.id)
-            .send(ctx.device, pulled)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/resource/mod.rs
+++ b/edgehog-device-runtime-containers/src/resource/mod.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@
 use std::future::Future;
 
 use async_trait::async_trait;
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -92,14 +92,19 @@ pub(crate) trait Resource<D>: Sized
 where
     D: Client + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()>;
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()>;
 }
 
 pub(crate) trait Create<D>: Resource<D>
 where
     D: Client + Send + Sync + 'static,
 {
-    fn fetch(ctx: &mut Context<'_, D>) -> impl Future<Output = Result<(State, Self)>> + Send;
+    const RESOURCE_NAME: &'static str;
+
+    /// Fetches and updates the state of the resource
+    fn fetch(
+        ctx: &mut Context<'_, D>,
+    ) -> impl Future<Output = Result<Option<(State, Self)>>> + Send;
 
     fn create(&mut self, ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
 
@@ -107,10 +112,21 @@ where
 
     fn unset(&mut self, ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
 
-    fn refresh(ctx: &mut Context<'_, D>) -> impl Future<Output = Result<()>> + Send;
+    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
+        if Self::fetch(ctx).await?.is_none() {
+            warn!("couldn't find {}", Self::RESOURCE_NAME);
+        }
+
+        Ok(())
+    }
 
     async fn up(mut ctx: Context<'_, D>) -> Result<Self> {
-        let (state, mut resource) = Self::fetch(&mut ctx).await?;
+        let (state, mut resource) = Self::fetch(&mut ctx).await.and_then(|opt| {
+            opt.ok_or(ResourceError::Missing {
+                id: ctx.id,
+                resource: Self::RESOURCE_NAME,
+            })
+        })?;
 
         match state {
             State::Missing => {
@@ -127,7 +143,12 @@ where
     }
 
     async fn down(mut ctx: Context<'_, D>) -> Result<()> {
-        let (state, mut resource) = Self::fetch(&mut ctx).await?;
+        let (state, mut resource) = Self::fetch(&mut ctx).await.and_then(|opt| {
+            opt.ok_or(ResourceError::Missing {
+                id: ctx.id,
+                resource: Self::RESOURCE_NAME,
+            })
+        })?;
 
         match state {
             State::Missing => {

--- a/edgehog-device-runtime-containers/src/resource/network.rs
+++ b/edgehog-device-runtime-containers/src/resource/network.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,14 +18,13 @@
 
 use async_trait::async_trait;
 use edgehog_store::models::containers::network::NetworkStatus;
-use tracing::warn;
 
 use crate::{
     network::Network,
     properties::{network::AvailableNetwork, AvailableProp, Client},
 };
 
-use super::{Context, Create, Resource, ResourceError, Result, State};
+use super::{Context, Create, Resource, Result, State};
 
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkResource {
@@ -43,7 +42,7 @@ impl<D> Resource<D> for NetworkResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableNetwork::new(&ctx.id)
             .send(ctx.device, false)
             .await?;
@@ -51,6 +50,8 @@ where
         ctx.store
             .update_network_status(ctx.id, NetworkStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -60,26 +61,27 @@ impl<D> Create<D> for NetworkResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let mut resource = ctx
-            .store
-            .find_network(ctx.id)
-            .await?
-            .ok_or(ResourceError::Missing {
-                id: ctx.id,
-                resource: "network",
-            })?;
+    const RESOURCE_NAME: &'static str = "network";
 
-        let exists = resource.network.inspect(ctx.client).await?.is_some();
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(mut resource) = ctx.store.find_network(ctx.id).await? else {
+            return Ok(None);
+        };
 
-        if exists {
+        let created = resource.network.inspect(ctx.client).await?.is_some();
+
+        AvailableNetwork::new(&ctx.id)
+            .send(ctx.device, created)
+            .await?;
+
+        if created {
             ctx.store
                 .update_network_local_id(ctx.id, resource.network.id.id.clone())
                 .await?;
 
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -111,22 +113,6 @@ where
         AvailableNetwork::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_network(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        let Some(mut resource) = ctx.store.find_network(ctx.id).await? else {
-            warn!("couldn't find network");
-
-            return Ok(());
-        };
-
-        let created = resource.network.inspect(ctx.client).await?.is_some();
-
-        AvailableNetwork::new(&ctx.id)
-            .send(ctx.device, created)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/resource/volume.rs
+++ b/edgehog-device-runtime-containers/src/resource/volume.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,14 +18,13 @@
 
 use async_trait::async_trait;
 use edgehog_store::models::containers::volume::VolumeStatus;
-use tracing::warn;
 
 use crate::{
     properties::{volume::AvailableVolume, AvailableProp, Client},
-    volume::{Volume, VolumeId},
+    volume::Volume,
 };
 
-use super::{Context, Create, Resource, ResourceError, Result, State};
+use super::{Context, Create, Resource, Result, State};
 
 #[derive(Debug, Clone)]
 pub(crate) struct VolumeResource {
@@ -43,7 +42,7 @@ impl<D> Resource<D> for VolumeResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn publish(ctx: Context<'_, D>) -> Result<()> {
+    async fn publish(ctx: &mut Context<'_, D>) -> Result<()> {
         AvailableVolume::new(&ctx.id)
             .send(ctx.device, false)
             .await?;
@@ -51,6 +50,8 @@ where
         ctx.store
             .update_volume_status(ctx.id, VolumeStatus::Published)
             .await?;
+
+        Self::fetch(ctx).await?;
 
         Ok(())
     }
@@ -60,22 +61,23 @@ impl<D> Create<D> for VolumeResource
 where
     D: Client + Send + Sync + 'static,
 {
-    async fn fetch(ctx: &mut Context<'_, D>) -> Result<(State, Self)> {
-        let resource = ctx
-            .store
-            .find_volume(ctx.id)
-            .await?
-            .ok_or(ResourceError::Missing {
-                id: ctx.id,
-                resource: "volume",
-            })?;
+    const RESOURCE_NAME: &'static str = "voulume";
+
+    async fn fetch(ctx: &mut Context<'_, D>) -> Result<Option<(State, Self)>> {
+        let Some(resource) = ctx.store.find_volume(ctx.id).await? else {
+            return Ok(None);
+        };
 
         let exists = resource.volume.inspect(ctx.client).await?.is_some();
 
+        AvailableVolume::new(&ctx.id)
+            .send(ctx.device, exists)
+            .await?;
+
         if exists {
-            Ok((State::Created, resource))
+            Ok(Some((State::Created, resource)))
         } else {
-            Ok((State::Missing, resource))
+            Ok(Some((State::Missing, resource)))
         }
     }
 
@@ -101,24 +103,6 @@ where
         AvailableVolume::new(&ctx.id).unset(ctx.device).await?;
 
         ctx.store.delete_volume(ctx.id).await?;
-
-        Ok(())
-    }
-
-    async fn refresh(ctx: &mut Context<'_, D>) -> Result<()> {
-        if !ctx.store.check_volume_exists(ctx.id).await? {
-            warn!("couldn't find volume");
-
-            return Ok(());
-        };
-
-        let volume_id = VolumeId::new(ctx.id);
-
-        let created = volume_id.inspect(ctx.client).await?.is_some();
-
-        AvailableVolume::new(&ctx.id)
-            .send(ctx.device, created)
-            .await?;
 
         Ok(())
     }

--- a/edgehog-device-runtime-containers/src/service/mod.rs
+++ b/edgehog-device-runtime-containers/src/service/mod.rs
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -141,23 +141,33 @@ impl<D> Service<D> {
         D: Client + Send + Sync + 'static,
     {
         for id in self.store.load_images_to_publish().await? {
-            ImageResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            ImageResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_volumes_to_publish().await? {
-            VolumeResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            VolumeResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_networks_to_publish().await? {
-            NetworkResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            NetworkResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_device_mappings_to_publish().await? {
-            DeviceMappingResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            DeviceMappingResource::publish(&mut context).await?;
         }
 
         for id in self.store.load_containers_to_publish().await? {
-            ContainerResource::publish(self.context(id)).await?;
+            let mut context = self.context(id);
+
+            ContainerResource::publish(&mut context).await?;
         }
 
         for id in self
@@ -165,7 +175,7 @@ impl<D> Service<D> {
             .load_deployments_in(DeploymentStatus::Received)
             .await?
         {
-            Deployment::publish(self.context(id)).await?;
+            Deployment::publish(&mut self.context(id)).await?;
         }
 
         Ok(())
@@ -277,14 +287,16 @@ impl<D> Service<D> {
         D: Client + Send + Sync + 'static,
     {
         let res = match id.resource_type() {
-            ResourceType::Image => ImageResource::publish(self.context(*id.uuid())).await,
-            ResourceType::Volume => VolumeResource::publish(self.context(*id.uuid())).await,
-            ResourceType::Network => NetworkResource::publish(self.context(*id.uuid())).await,
+            ResourceType::Image => ImageResource::publish(&mut self.context(*id.uuid())).await,
+            ResourceType::Volume => VolumeResource::publish(&mut self.context(*id.uuid())).await,
+            ResourceType::Network => NetworkResource::publish(&mut self.context(*id.uuid())).await,
             ResourceType::DeviceMapping => {
-                DeviceMappingResource::publish(self.context(*id.uuid())).await
+                DeviceMappingResource::publish(&mut self.context(*id.uuid())).await
             }
-            ResourceType::Container => ContainerResource::publish(self.context(*id.uuid())).await,
-            ResourceType::Deployment => Deployment::publish(self.context(*id.uuid())).await,
+            ResourceType::Container => {
+                ContainerResource::publish(&mut self.context(*id.uuid())).await
+            }
+            ResourceType::Deployment => Deployment::publish(&mut self.context(*id.uuid())).await,
         };
 
         if let Err(err) = res {
@@ -482,7 +494,13 @@ impl<D> Service<D> {
             debug!(%id, "stopping container");
 
             let mut ctx = self.context(*id);
-            let (state, mut container) = ContainerResource::fetch(&mut ctx).await?;
+            let (state, mut container) =
+                ContainerResource::fetch(&mut ctx).await.and_then(|opt| {
+                    opt.ok_or(ResourceError::Missing {
+                        id: ctx.id,
+                        resource: "container",
+                    })
+                })?;
 
             match state {
                 State::Missing => {
@@ -802,7 +820,13 @@ impl<D> Service<D> {
             debug!(%id, "restarting container");
 
             let mut ctx = self.context(*id);
-            let (state, mut container) = ContainerResource::fetch(&mut ctx).await?;
+            let (state, mut container) =
+                ContainerResource::fetch(&mut ctx).await.and_then(|opt| {
+                    opt.ok_or(ResourceError::Missing {
+                        id: ctx.id,
+                        resource: "container",
+                    })
+                })?;
 
             match state {
                 State::Missing => {
@@ -916,6 +940,7 @@ mod tests {
     use crate::requests::network::tests::create_network_request_event;
     use crate::requests::volume::tests::create_volume_request_event;
     use crate::requests::ContainerRequest;
+    use crate::tests::not_found_response;
     use crate::volume::{Volume, VolumeId};
     use crate::{docker, docker_mock};
 
@@ -944,14 +969,175 @@ mod tests {
         (service, handle)
     }
 
+    fn expect_image(
+        id: Uuid,
+        reference: &str,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        let image_path = format!("/{id}/pulled");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path.clone()),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_image()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(reference.to_string()))
+            .returning(|_| Err(not_found_response()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
+    fn expect_volume(
+        id: Uuid,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        let endpoint = format!("/{id}/created");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableVolumes"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_volume()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(id.to_string()))
+            .returning(|_| Err(not_found_response()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableVolumes"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
+    fn expect_network(
+        id: Uuid,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        let endpoint = format!("/{id}/created");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_network()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(id.to_string()), predicate::always())
+            .returning(|_, _| Err(not_found_response()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
+    fn expect_container(
+        id: Uuid,
+        device_mapping_id: Uuid,
+        seq: &mut Sequence,
+        device: &mut MockDeviceClient<Mqtt<SqliteStore>>,
+        client: &mut Docker,
+    ) {
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableDeviceMappings"),
+                predicate::eq(format!("/{device_mapping_id}/present")),
+                predicate::eq(AstarteData::Boolean(true)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let endpoint = format!("/{id}/status");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        client
+            .expect_inspect_container()
+            .once()
+            .in_sequence(seq)
+            .with(predicate::eq(id.to_string()), predicate::always())
+            .returning(|_, _| Err(not_found_response()));
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+    }
+
     #[tokio::test]
     async fn should_add_an_image() {
         let tmpdir = TempDir::new().unwrap();
 
         let id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
+        let reference = "docker.io/nginx:stable-alpine-slim";
 
-        let client = Docker::connect().await.unwrap();
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -961,21 +1147,10 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let image_path = format!("/{id}/pulled");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
-                predicate::eq(image_path),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_image(id, reference, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tmpdir, client, device).await;
 
-        let reference = "docker.io/nginx:stable-alpine-slim";
         let create_image_req = create_image_request_event(id, deployment_id, reference, "");
 
         let req = ContainerRequest::from_event(create_image_req).unwrap();
@@ -999,7 +1174,7 @@ mod tests {
         let id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
 
-        let client = Docker::connect().await.unwrap();
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -1009,17 +1184,7 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let endpoint = format!("/{id}/created");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableVolumes"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_volume(id, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tempdir, client, device).await;
 
@@ -1053,7 +1218,7 @@ mod tests {
         let id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
 
-        let client = Docker::connect().await.unwrap();
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -1063,17 +1228,7 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let endpoint = format!("/{id}/created");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_network(id, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tempdir, client, device).await;
 
@@ -1109,7 +1264,9 @@ mod tests {
         let device_mapping_id = Uuid::new_v4();
         let deployment_id = Uuid::new_v4();
 
-        let client = Docker::connect().await.unwrap();
+        let reference = "docker.io/nginx:stable-alpine-slim";
+
+        let mut client = Docker::connect().await.unwrap();
         let mut device = MockDeviceClient::<Mqtt<SqliteStore>>::new();
         let mut seq = Sequence::new();
 
@@ -1119,57 +1276,13 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(MockDeviceClient::<Mqtt<SqliteStore>>::new);
 
-        let image_path = format!("/{image_id}/pulled");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
-                predicate::eq(image_path),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
-
-        let endpoint = format!("/{network_id}/created");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableNetworks"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::Boolean(false)),
-            )
-            .returning(|_, _, _| Ok(()));
-
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableDeviceMappings"),
-                predicate::eq(format!("/{device_mapping_id}/present")),
-                predicate::eq(AstarteData::Boolean(true)),
-            )
-            .returning(|_, _, _| Ok(()));
-
-        let endpoint = format!("/{id}/status");
-        device
-            .expect_set_property()
-            .once()
-            .in_sequence(&mut seq)
-            .with(
-                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
-                predicate::eq(endpoint),
-                predicate::eq(AstarteData::from("Received")),
-            )
-            .returning(|_, _, _| Ok(()));
+        expect_image(image_id, reference, &mut seq, &mut device, &mut client);
+        expect_network(network_id, &mut seq, &mut device, &mut client);
+        expect_container(id, device_mapping_id, &mut seq, &mut device, &mut client);
 
         let (mut service, mut handle) = mock_service(&tempdir, client, device).await;
 
-        // Image
-        let reference = "docker.io/nginx:stable-alpine-slim";
+        // image
         let create_image_req = create_image_request_event(image_id, deployment_id, reference, "");
 
         let req = ContainerRequest::from_event(create_image_req).unwrap();
@@ -1280,6 +1393,19 @@ mod tests {
                 .in_sequence(&mut seq)
                 .returning(|_| Err(not_found_response()));
 
+            let container_name = container_id.to_string();
+            mock.expect_inspect_container()
+                .times(1)
+                .in_sequence(&mut seq)
+                .with(predicate::eq(container_name.clone()), predicate::always())
+                .returning(|_, _| Err(docker::tests::not_found_response()));
+
+            mock.expect_inspect_image()
+                .withf(move |name| name == reference)
+                .once()
+                .in_sequence(&mut seq)
+                .returning(|_| Err(not_found_response()));
+
             mock.expect_create_image()
                 .with(
                     predicate::eq(Some(CreateImageOptions {
@@ -1306,11 +1432,10 @@ mod tests {
                 })
                 });
 
-            let container_name = container_id.to_string();
             mock.expect_inspect_container()
-                .withf(move |name, _option| name == container_name)
-                .once()
+                .times(1)
                 .in_sequence(&mut seq)
+                .with(predicate::eq(container_name), predicate::always())
                 .returning(|_, _| Err(docker::tests::not_found_response()));
 
             let name_exp = container_id.to_string();
@@ -1354,7 +1479,7 @@ mod tests {
         let image_path = format!("/{image_id}/pulled");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
@@ -1366,7 +1491,7 @@ mod tests {
         let endpoint = format!("/{container_id}/status");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
@@ -1407,11 +1532,23 @@ mod tests {
             .expect_set_property()
             .once()
             .in_sequence(&mut seq)
-            .withf(move |interface, path, value| {
-                interface == "io.edgehog.devicemanager.apps.AvailableImages"
-                    && path == (image_path)
-                    && *value == AstarteData::Boolean(true)
-            })
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let image_path = format!("/{image_id}/pulled");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(true)),
+            )
             .returning(|_, _, _| Ok(()));
 
         let endpoint = format!("/{container_id}/status");
@@ -1419,11 +1556,22 @@ mod tests {
             .expect_set_property()
             .once()
             .in_sequence(&mut seq)
-            .withf(move |interface, path, value| {
-                interface == "io.edgehog.devicemanager.apps.AvailableContainers"
-                    && path == endpoint
-                    && *value == ContainerStatus::Created.to_string()
-            })
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint.clone()),
+                predicate::eq(AstarteData::String(ContainerStatus::Created.to_string())),
+            )
             .returning(|_, _, _| Ok(()));
 
         let endpoint = format!("/{container_id}/status");
@@ -1525,10 +1673,16 @@ mod tests {
             let mut mock = docker::Client::new();
             let mut seq = mockall::Sequence::new();
 
+            mock.expect_inspect_image()
+                .withf(move |name| name == reference)
+                .once()
+                .in_sequence(&mut seq)
+                .returning(|_| Err(not_found_response()));
+
             let container_name = container_id.to_string();
             mock.expect_inspect_container()
                 .withf(move |name, _option| name == container_name)
-                .once()
+                .times(2)
                 .in_sequence(&mut seq)
                 .returning(|_, _| Err(docker::tests::not_found_response()));
 
@@ -1552,7 +1706,7 @@ mod tests {
         let image_path = format!("/{image_id}/pulled");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
@@ -1564,7 +1718,7 @@ mod tests {
         let endpoint = format!("/{container_id}/status");
         device
             .expect_set_property()
-            .once()
+            .times(2)
             .in_sequence(&mut seq)
             .with(
                 predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
@@ -1602,6 +1756,18 @@ mod tests {
 
         let endpoint = format!("/{container_id}/status");
         device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableContainers"),
+                predicate::eq(endpoint),
+                predicate::eq(AstarteData::from("Received")),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let endpoint = format!("/{container_id}/status");
+        device
             .expect_unset_property()
             .once()
             .in_sequence(&mut seq)
@@ -1610,6 +1776,18 @@ mod tests {
                 predicate::eq(endpoint),
             )
             .returning(|_, _| Ok(()));
+
+        let image_path = format!("/{image_id}/pulled");
+        device
+            .expect_set_property()
+            .once()
+            .in_sequence(&mut seq)
+            .with(
+                predicate::eq("io.edgehog.devicemanager.apps.AvailableImages"),
+                predicate::eq(image_path),
+                predicate::eq(AstarteData::Boolean(false)),
+            )
+            .returning(|_, _, _| Ok(()));
 
         let image_path = format!("/{image_id}/pulled");
         device


### PR DESCRIPTION
Move the refresh logic into the fetch method to update the resources status when we start a deployment.