### PR TITLE
refactor(interfaces): add submodule for edgehog-astarte-interfaces

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -51,13 +51,6 @@ jobs:
       - uses: ./.github/actions/install-deps
       - uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
       - uses: mozilla-actions/sccache-action@v0.0.10
-      - name: Checkout edgehog-astarte-interfaces
-        uses: actions/checkout@v7
-        with:
-          repository: edgehog-device-manager/edgehog-astarte-interfaces.git
-          # Update ref when updated interfaces are required.
-          ref: main
-          path: ./edgehog/astarte-interfaces
       - run: ./scripts/ci/e2e-test.sh
       - name: post
         if: ${{ failure() || cancelled() }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,7 @@
 	path = deps/forwarder-proto
 	url = https://github.com/edgehog-device-manager/edgehog-device-forwarder-proto.git
 	branch = main
+[submodule "deps/interfaces"]
+	path = deps/interfaces
+	url = https://github.com/edgehog-device-manager/edgehog-astarte-interfaces.git
+	branch = main

--- a/_typos.toml
+++ b/_typos.toml
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+[default.extend-identifiers]
+UTRANwHSDPAandHSUPA = "UTRANwHSDPAandHSUPA"
 
 [default.extend-words]
 tung = "tung"

--- a/scripts/ci/e2e-test.sh
+++ b/scripts/ci/e2e-test.sh
@@ -32,7 +32,7 @@ export E2E_REALM=${E2E_REALM:-test}
 export E2E_BASE_DOMAIN=${E2E_BASE_DOMAIN:-autotest.astarte-platform.org}
 export E2E_IGNORE_SSL=${E2E_IGNORE_SSL:-false}
 export E2E_API_URL=${E2E_API_URL:-https://api.$E2E_BASE_DOMAIN}
-export E2E_INTERFACE_DIR=${E2E_INTERFACE_DIR:-edgehog/astarte-interfaces}
+export E2E_INTERFACE_DIR=${E2E_INTERFACE_DIR:-deps/interfaces}
 
 # Install interfaces
 astartectl realm-management interfaces sync --non-interactive "$E2E_INTERFACE_DIR"/*.json


### PR DESCRIPTION
This way we can include them in the binary directly and keep them in
sync with developments.
