### PR TITLE
refactor(ota): make it possible to disable it via config

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -58,7 +58,7 @@ pub struct Runtime<T> {
     #[cfg(all(feature = "zbus", target_os = "linux"))]
     led_tx: mpsc::Sender<LedEvent>,
     #[cfg(all(feature = "zbus", target_os = "linux"))]
-    ota_handler: OtaHandler,
+    ota_handler: Option<OtaHandler>,
 }
 
 impl<C> Runtime<C> {
@@ -96,9 +96,15 @@ impl<C> Runtime<C> {
         let container_handle = std::sync::Arc::new(tokio::sync::OnceCell::new());
 
         #[cfg(all(feature = "zbus", target_os = "linux"))]
-        let ota_handler = OtaHandler::start(tasks, cancel.child_token(), client.clone(), &opts)
-            .await
-            .wrap_err("couldn't initialize ota handler")?;
+        let ota_handler = if opts.ota.enabled {
+            let handle = OtaHandler::start(tasks, cancel.child_token(), client.clone(), &opts)
+                .await
+                .wrap_err("couldn't initialize ota handler")?;
+
+            Some(handle)
+        } else {
+            None
+        };
 
         #[cfg(all(feature = "zbus", target_os = "linux"))]
         let led_tx = {
@@ -394,7 +400,12 @@ impl<C> Runtime<C> {
         match event {
             RuntimeEvent::Command(cmd) => {
                 #[cfg(all(feature = "zbus", target_os = "linux"))]
-                if cmd.is_reboot() && self.ota_handler.in_progress() {
+                if cmd.is_reboot()
+                    && self
+                        .ota_handler
+                        .as_ref()
+                        .is_some_and(|handle| handle.in_progress())
+                {
                     error!("cannot reboot during OTA update");
 
                     return;
@@ -439,13 +450,20 @@ impl<C> Runtime<C> {
             }
             #[cfg(all(feature = "zbus", target_os = "linux"))]
             RuntimeEvent::Ota(ota) => {
-                if let Err(error) = self.ota_handler.handle_event(ota).await {
+                let Some(ota_handler) = &mut self.ota_handler else {
+                    error!("the ota feature is disabled");
+
+                    return;
+                };
+
+                if let Err(error) = ota_handler.handle_event(ota).await {
                     error!(
                         %error,
                         "error while processing ota event",
                     );
                 }
             }
+
             #[cfg(feature = "containers")]
             RuntimeEvent::Container(event) => {
                 if let Some(containers_tx) = &self.containers_tx {

--- a/src/ota/config.rs
+++ b/src/ota/config.rs
@@ -1,12 +1,12 @@
 // This file is part of Edgehog.
 //
-// Copyright 2025 SECO Mind Srl
+// Copyright 2025, 2026 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,8 +20,10 @@ use std::fmt::Display;
 
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 pub struct OtaConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     #[serde(default)]
     pub reboot: Reboot,
     #[serde(default)]
@@ -29,6 +31,21 @@ pub struct OtaConfig {
     /// RAUC configuration for the OTA
     #[serde(default)]
     pub rauc: RaucConfig,
+}
+
+impl Default for OtaConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            reboot: Default::default(),
+            streaming: Default::default(),
+            rauc: Default::default(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
@@ -74,6 +91,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn default_values() {
+        let exp = OtaConfig {
+            enabled: true,
+            reboot: Reboot::Default,
+            streaming: false,
+            rauc: RaucConfig {
+                dbus_socket: RaucDbus::System,
+            },
+        };
+
+        assert_eq!(OtaConfig::default(), exp);
+    }
+
+    #[test]
     fn should_deserialize() {
         let string = r#"
         reboot = "external"
@@ -83,6 +114,7 @@ mod tests {
         let config: OtaConfig = toml::from_str(string).unwrap();
 
         let exp = OtaConfig {
+            enabled: true,
             reboot: Reboot::External,
             streaming: true,
             rauc: RaucConfig {
@@ -101,6 +133,7 @@ mod tests {
         let config: OtaConfig = toml::from_str(string).unwrap();
 
         let exp = OtaConfig {
+            enabled: true,
             reboot: Reboot::Default,
             streaming: false,
             rauc: RaucConfig {
@@ -121,10 +154,31 @@ mod tests {
         let config: OtaConfig = toml::from_str(string).unwrap();
 
         let exp = OtaConfig {
+            enabled: true,
             reboot: Reboot::Default,
             streaming: false,
             rauc: RaucConfig {
                 dbus_socket: RaucDbus::Session,
+            },
+        };
+
+        assert_eq!(config, exp);
+    }
+
+    #[test]
+    fn should_disable() {
+        let string = r#"
+        enabled = false
+        "#;
+
+        let config: OtaConfig = toml::from_str(string).unwrap();
+
+        let exp = OtaConfig {
+            enabled: false,
+            reboot: Reboot::Default,
+            streaming: false,
+            rauc: RaucConfig {
+                dbus_socket: RaucDbus::default(),
             },
         };
 


### PR DESCRIPTION
Add a config option to the ota to enable or diable it. In dev this let
you test the dbus functionality without having rauc installed on you
workstation.

The option is enable by default and we test that old configurations are
still valid.