### PR TITLE
refactor(interfaces): bundle the interfaces in the binary 

### DIFF
--- a/e2e-test/src/main.rs
+++ b/e2e-test/src/main.rs
@@ -27,7 +27,6 @@ use reqwest::Response;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
-use std::path::PathBuf;
 use std::time::Duration;
 use tempdir::TempDir;
 use tokio::task::JoinSet;
@@ -68,9 +67,6 @@ struct Cli {
     /// Ignore SSL errors when talking to MQTT Broker.
     #[arg(long, env = "E2E_IGNORE_SSL")]
     ignore_ssl: bool,
-    /// Interface directory for the Device.
-    #[arg(short, long, env = "E2E_INTERFACE_DIR")]
-    interface_dir: PathBuf,
 }
 
 impl Cli {
@@ -143,7 +139,6 @@ async fn main() -> color_eyre::Result<()> {
     let device_options = DeviceManagerOptions {
         astarte_library: AstarteLibrary::AstarteDeviceSdk,
         astarte_device_sdk: Some(astarte_options.clone()),
-        interfaces_directory: cli.interface_dir.clone(),
         store_directory: store_path.path().to_path_buf(),
         download_directory: store_path.path().join("downloads"),
         telemetry_config: Some(Vec::new()),
@@ -156,6 +151,7 @@ async fn main() -> color_eyre::Result<()> {
         #[cfg(target_os = "linux")]
         ota: edgehog_device_runtime::ota::config::OtaConfig::default(),
         file_transfer: FileTransferArgs::with_store_dir(None, store_path.path()),
+        interfaces_directory: None,
     };
 
     let store = connect_store(store_path.path())
@@ -165,12 +161,7 @@ async fn main() -> color_eyre::Result<()> {
     let mut tasks = JoinSet::new();
 
     let client = astarte_options
-        .connect(
-            &mut tasks,
-            store,
-            &device_options.store_directory,
-            &device_options.interfaces_directory,
-        )
+        .connect(&mut tasks, store, &device_options.store_directory)
         .await
         .wrap_err("couldn't connect to astarte")?;
 

--- a/scripts/ci/check-for-publish.sh
+++ b/scripts/ci/check-for-publish.sh
@@ -62,7 +62,7 @@ pkgsFiles=$(
         sort
 )
 localFiles=$(
-    git ls-files -cdmo | sort -u
+    git ls-files --recurse-submodules --cached --no-deleted | sort -u
 )
 
 # List files unique to localFiles and not present in pkgsFiles

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -72,10 +72,6 @@ impl TryFrom<Config> for DeviceManagerOptions {
             .map(|opt| opt.try_into())
             .transpose()?;
 
-        let interfaces_directory = value
-            .interfaces_directory
-            .ok_or_eyre("config is missing interfaces directory")?;
-
         let store_directory = value
             .store_directory
             .ok_or_eyre("config is missing store directory")?;
@@ -107,7 +103,7 @@ impl TryFrom<Config> for DeviceManagerOptions {
             ota,
             #[cfg(feature = "file-transfer")]
             file_transfer,
-            interfaces_directory,
+            interfaces_directory: value.interfaces_directory,
             store_directory,
             download_directory,
             telemetry_config: value.telemetry_config,

--- a/src/data/astarte_device_sdk_lib.rs
+++ b/src/data/astarte_device_sdk_lib.rs
@@ -32,6 +32,8 @@ use url::Url;
 use crate::repository::StateRepository;
 use crate::repository::file_state_repository::FileStateRepository;
 
+use super::interfaces::add_interfaces;
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct AstarteDeviceSdkConfigOptions {
     pub realm: String,
@@ -98,7 +100,6 @@ impl AstarteDeviceSdkConfigOptions {
         tasks: &mut JoinSet<eyre::Result<()>>,
         store: SqliteStore,
         store_dir: P,
-        interface_dir: P,
     ) -> eyre::Result<DeviceClient<Mqtt<SqliteStore, PairingApi>>>
     where
         P: AsRef<Path>,
@@ -118,8 +119,8 @@ impl AstarteDeviceSdkConfigOptions {
             mqtt_cfg = mqtt_cfg.ignore_ssl_errors();
         }
 
-        let (client, connection) = DeviceBuilder::new()
-            .interface_directory(interface_dir)?
+        let (client, connection) = add_interfaces(DeviceBuilder::new())
+            .wrap_err("couldn't add interfaces")?
             .writable_dir(store_dir)
             .store(store)
             .connection(mqtt_cfg)

--- a/src/data/astarte_message_hub_node.rs
+++ b/src/data/astarte_message_hub_node.rs
@@ -21,31 +21,20 @@
 use std::path::Path;
 
 use astarte_device_sdk::DeviceClient;
-use astarte_device_sdk::astarte_device_error::Error;
 use astarte_device_sdk::builder::DeviceBuilder;
-use astarte_device_sdk::error::AstarteError;
 use astarte_device_sdk::prelude::*;
 use astarte_device_sdk::store::SqliteStore;
-use astarte_device_sdk::transport::grpc::error::GrpcError;
 use astarte_device_sdk::transport::grpc::{Grpc, GrpcConfig};
+use eyre::Context;
 use serde::Deserialize;
 use tokio::task::JoinSet;
 use url::Url;
 use uuid::{Uuid, uuid};
 
+use super::interfaces::add_interfaces;
+
 /// Device runtime node identifier.
 const DEVICE_RUNTIME_NODE_UUID: Uuid = uuid!("d72a6187-7cf1-44cc-87e8-e991936166db");
-
-/// Error returned by the [`astarte_device_sdk`].
-#[derive(Debug, thiserror::Error, displaydoc::Display)]
-pub enum MessageHubError {
-    /// missing configuration for the Astarte Message Hub
-    MissingConfig,
-    /// couldn't connect to Astarte
-    Connect(#[from] AstarteError),
-    /// Invalid endpoint
-    Endpoint(#[from] Error<GrpcError>),
-}
 
 /// Struct containing the configuration options for the Astarte message hub.
 #[derive(Debug, Deserialize, Clone)]
@@ -59,21 +48,22 @@ impl AstarteMessageHubOptions {
         &self,
         tasks: &mut JoinSet<eyre::Result<()>>,
         store: SqliteStore,
-        interface_dir: P,
-    ) -> Result<DeviceClient<Grpc<SqliteStore>>, MessageHubError>
+        store_dir: P,
+    ) -> eyre::Result<DeviceClient<Grpc<SqliteStore>>>
     where
         P: AsRef<Path>,
     {
         let grpc_cfg = GrpcConfig::from_url(DEVICE_RUNTIME_NODE_UUID, self.endpoint.to_string())
-            .map_err(MessageHubError::Endpoint)?;
+            .wrap_err("invalid message-hub endpoint")?;
 
-        let (device, connection) = DeviceBuilder::new()
+        let (device, connection) = add_interfaces(DeviceBuilder::new())
+            .wrap_err("couldn't add interfaces")?
+            .writable_dir(store_dir)
             .store(store)
-            .interface_directory(interface_dir)?
             .connection(grpc_cfg)
             .build()
             .await
-            .map_err(MessageHubError::Connect)?;
+            .wrap_err("couldn't connect to Astarte")?;
 
         tasks.spawn(async move { connection.handle_events().await.map_err(Into::into) });
 

--- a/src/data/interfaces.rs
+++ b/src/data/interfaces.rs
@@ -1,0 +1,294 @@
+// This file is part of Edgehog.
+//
+// Copyright 2026 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Edgehog interfaces to files to embed into the program.
+
+use astarte_device_sdk::builder::DeviceBuilder;
+
+const BASE_IMAGE: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.BaseImage.json");
+const BATTERY_STATUS: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.BatteryStatus.json");
+const COMMANDS: &str = include_str!("../../deps/interfaces/io.edgehog.devicemanager.Commands.json");
+const HARDWARE_INFO: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.HardwareInfo.json");
+const OS_INFO: &str = include_str!("../../deps/interfaces/io.edgehog.devicemanager.OSInfo.json");
+const RUNTIME_INFO: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.RuntimeInfo.json");
+const STORAGE_USAGE: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.StorageUsage.json");
+const SYSTEM_INFO: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.SystemInfo.json");
+const SYSTEM_STATUS: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.SystemStatus.json");
+const CONFIG_TELEMETRY: &str =
+    include_str!("../../deps/interfaces/io.edgehog.devicemanager.config.Telemetry.json");
+
+/// Add the enabled interfaces
+pub(crate) fn add_interfaces<C, S>(
+    mut builder: DeviceBuilder<C, S>,
+) -> eyre::Result<DeviceBuilder<C, S>> {
+    builder = builder
+        .interface_str(BASE_IMAGE)?
+        .interface_str(BATTERY_STATUS)?
+        .interface_str(COMMANDS)?
+        .interface_str(HARDWARE_INFO)?
+        .interface_str(OS_INFO)?
+        .interface_str(RUNTIME_INFO)?
+        .interface_str(STORAGE_USAGE)?
+        .interface_str(SYSTEM_INFO)?
+        .interface_str(SYSTEM_STATUS)?
+        .interface_str(CONFIG_TELEMETRY)?;
+
+    #[cfg(all(feature = "zbus", target_os = "linux"))]
+    {
+        builder = add_zbus_linux(builder)?;
+    }
+
+    #[cfg(feature = "forwarder")]
+    {
+        builder = add_forwarder(builder)?;
+    }
+
+    #[cfg(all(feature = "udev", target_os = "linux"))]
+    {
+        builder = add_udev_linux(builder)?;
+    }
+
+    #[cfg(feature = "wifiscanner")]
+    {
+        builder = add_wifi_scan(builder)?;
+    }
+
+    #[cfg(feature = "containers")]
+    {
+        builder = add_containers(builder)?;
+    }
+
+    #[cfg(feature = "file-transfer")]
+    {
+        builder = add_file_transfer(builder)?;
+    }
+
+    Ok(builder)
+}
+
+#[cfg(feature = "forwarder")]
+fn add_forwarder<S, C>(
+    mut builder: DeviceBuilder<C, S>,
+) -> Result<DeviceBuilder<C, S>, eyre::Error> {
+    const FORWARDER_SESSION_REQUEST: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.ForwarderSessionRequest.json");
+    const FORWARDER_SESSION_STATE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.ForwarderSessionState.json");
+
+    builder = builder
+        .interface_str(FORWARDER_SESSION_REQUEST)?
+        .interface_str(FORWARDER_SESSION_STATE)?;
+
+    Ok(builder)
+}
+
+#[cfg(all(feature = "zbus", target_os = "linux"))]
+fn add_zbus_linux<C, S>(
+    mut builder: DeviceBuilder<C, S>,
+) -> Result<DeviceBuilder<C, S>, eyre::Error> {
+    const CELLULAR_CONNECTION_PROPERTIES: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.CellularConnectionProperties.json"
+    );
+    const GEOLOCATION: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.Geolocation.json");
+    const CELLULAR_CONNECTION_STATUS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.CellularConnectionStatus.json"
+    );
+    const LED_BEHAVIOR: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.LedBehavior.json");
+    const OTA_EVENT: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.OTAEvent.json");
+    const OTA_REQUEST: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.OTARequest.json");
+
+    builder = builder
+        .interface_str(CELLULAR_CONNECTION_PROPERTIES)?
+        .interface_str(GEOLOCATION)?
+        .interface_str(CELLULAR_CONNECTION_STATUS)?
+        .interface_str(LED_BEHAVIOR)?
+        .interface_str(OTA_EVENT)?
+        .interface_str(OTA_REQUEST)?;
+
+    Ok(builder)
+}
+
+#[cfg(all(feature = "udev", target_os = "linux"))]
+fn add_udev_linux<C, S>(
+    mut builder: DeviceBuilder<C, S>,
+) -> Result<DeviceBuilder<C, S>, eyre::Error> {
+    const NETWORK_INTERFACE_PROPERTIES: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.NetworkInterfaceProperties.json"
+    );
+
+    builder = builder.interface_str(NETWORK_INTERFACE_PROPERTIES)?;
+
+    Ok(builder)
+}
+
+#[cfg(feature = "wifiscanner")]
+fn add_wifi_scan<C, S>(
+    mut builder: DeviceBuilder<C, S>,
+) -> Result<DeviceBuilder<C, S>, eyre::Error> {
+    const WIFI_SCAN_RESULTS: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.WiFiScanResults.json");
+
+    builder = builder.interface_str(WIFI_SCAN_RESULTS)?;
+
+    Ok(builder)
+}
+
+#[cfg(feature = "containers")]
+fn add_containers<C, S>(
+    mut builder: DeviceBuilder<C, S>,
+) -> Result<DeviceBuilder<C, S>, eyre::Error> {
+    const APPS_AVAILABLE_CONTAINERS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableContainers.json"
+    );
+    const APPS_AVAILABLE_DEPLOYMENTS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableDeployments.json"
+    );
+    const APPS_AVAILABLE_DEVICE_MAPPINGS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableDeviceMappings.json"
+    );
+    const APPS_AVAILABLE_DEVICE_REQUESTS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableDeviceRequests.json"
+    );
+    const APPS_AVAILABLE_IMAGES: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableImages.json");
+    const APPS_AVAILABLE_NETWORKS: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableNetworks.json");
+    const APPS_AVAILABLE_VOLUMES: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.AvailableVolumes.json");
+    const APPS_CREATE_CONTAINER_REQUEST: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.CreateContainerRequest.json"
+    );
+    const APPS_CREATE_DEPLOYMENT_REQUEST: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.CreateDeploymentRequest.json"
+    );
+    const APPS_CREATE_DEVICE_MAPPING_REQUEST: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json"
+    );
+    const APPS_CREATE_DEVICE_REQUEST: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.CreateDeviceRequest.json"
+    );
+    const APPS_CREATE_IMAGE_REQUEST: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.CreateImageRequest.json");
+    const APPS_CREATE_NETWORK_REQUEST: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.CreateNetworkRequest.json"
+    );
+    const APPS_CREATE_VOLUME_REQUEST: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.CreateVolumeRequest.json"
+    );
+    const APPS_DEPLOYMENT_COMMAND: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.DeploymentCommand.json");
+    const APPS_DEPLOYMENT_EVENT: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.DeploymentEvent.json");
+    const APPS_DEPLOYMENT_UPDATE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.DeploymentUpdate.json");
+    const APPS_STATS_CONTAINER_BLKIO: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.stats.ContainerBlkio.json"
+    );
+    const APPS_STATS_CONTAINER_CPU: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.stats.ContainerCpu.json");
+    const APPS_STATS_CONTAINER_MEMORY: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.stats.ContainerMemory.json"
+    );
+    const APPS_STATS_CONTAINER_MEMORY_STATS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.stats.ContainerMemoryStats.json"
+    );
+    const APPS_STATS_CONTAINER_NETWORKS: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.stats.ContainerNetworks.json"
+    );
+    const APPS_STATS_CONTAINER_PROCESSES: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.apps.stats.ContainerProcesses.json"
+    );
+    const APPS_STATS_VOLUME_USAGE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.apps.stats.VolumeUsage.json");
+
+    builder = builder
+        .interface_str(APPS_AVAILABLE_CONTAINERS)?
+        .interface_str(APPS_AVAILABLE_DEPLOYMENTS)?
+        .interface_str(APPS_AVAILABLE_DEVICE_MAPPINGS)?
+        .interface_str(APPS_AVAILABLE_DEVICE_REQUESTS)?
+        .interface_str(APPS_AVAILABLE_IMAGES)?
+        .interface_str(APPS_AVAILABLE_NETWORKS)?
+        .interface_str(APPS_AVAILABLE_VOLUMES)?
+        .interface_str(APPS_CREATE_CONTAINER_REQUEST)?
+        .interface_str(APPS_CREATE_DEPLOYMENT_REQUEST)?
+        .interface_str(APPS_CREATE_DEVICE_MAPPING_REQUEST)?
+        .interface_str(APPS_CREATE_DEVICE_REQUEST)?
+        .interface_str(APPS_CREATE_IMAGE_REQUEST)?
+        .interface_str(APPS_CREATE_NETWORK_REQUEST)?
+        .interface_str(APPS_CREATE_VOLUME_REQUEST)?
+        .interface_str(APPS_DEPLOYMENT_COMMAND)?
+        .interface_str(APPS_DEPLOYMENT_EVENT)?
+        .interface_str(APPS_DEPLOYMENT_UPDATE)?
+        .interface_str(APPS_STATS_CONTAINER_BLKIO)?
+        .interface_str(APPS_STATS_CONTAINER_CPU)?
+        .interface_str(APPS_STATS_CONTAINER_MEMORY)?
+        .interface_str(APPS_STATS_CONTAINER_MEMORY_STATS)?
+        .interface_str(APPS_STATS_CONTAINER_NETWORKS)?
+        .interface_str(APPS_STATS_CONTAINER_PROCESSES)?
+        .interface_str(APPS_STATS_VOLUME_USAGE)?;
+
+    Ok(builder)
+}
+
+#[cfg(feature = "file-transfer")]
+fn add_file_transfer<C, S>(
+    mut builder: DeviceBuilder<C, S>,
+) -> Result<DeviceBuilder<C, S>, eyre::Error> {
+    const FILE_TRANSFER_CAPABILITIES: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.fileTransfer.Capabilities.json"
+    );
+    const FILE_TRANSFER_DEVICE_TO_SERVER: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.fileTransfer.DeviceToServer.json"
+    );
+    const FILE_TRANSFER_PROGRESS: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.fileTransfer.Progress.json");
+    const FILE_TRANSFER_RESPONSE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.fileTransfer.Response.json");
+    const FILE_TRANSFER_SERVER_TO_DEVICE: &str = include_str!(
+        "../../deps/interfaces/io.edgehog.devicemanager.fileTransfer.ServerToDevice.json"
+    );
+    const STORAGE_DELETE_FILE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.storage.DeleteFile.json");
+    const STORAGE_FILE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.storage.File.json");
+    const STORAGE_RESPONSE: &str =
+        include_str!("../../deps/interfaces/io.edgehog.devicemanager.storage.Response.json");
+
+    builder = builder
+        .interface_str(FILE_TRANSFER_CAPABILITIES)?
+        .interface_str(FILE_TRANSFER_DEVICE_TO_SERVER)?
+        .interface_str(FILE_TRANSFER_PROGRESS)?
+        .interface_str(FILE_TRANSFER_RESPONSE)?
+        .interface_str(FILE_TRANSFER_SERVER_TO_DEVICE)?
+        .interface_str(STORAGE_DELETE_FILE)?
+        .interface_str(STORAGE_FILE)?
+        .interface_str(STORAGE_RESPONSE)?;
+
+    Ok(builder)
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -30,6 +30,7 @@ use crate::Client;
 pub mod astarte_device_sdk_lib;
 #[cfg(feature = "message-hub")]
 pub mod astarte_message_hub_node;
+pub(crate) mod interfaces;
 
 /// Connect to the store.
 pub async fn connect_store<P>(store_dir: P) -> Result<SqliteStore, Error<SqliteError>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub struct DeviceManagerOptions {
     pub file_transfer: self::file_transfer::config::FileTransferArgs,
     #[cfg(all(feature = "zbus", target_os = "linux"))]
     pub ota: self::ota::config::OtaConfig,
-    pub interfaces_directory: PathBuf,
+    pub interfaces_directory: Option<PathBuf>,
     pub store_directory: PathBuf,
     pub download_directory: PathBuf,
     pub telemetry_config: Option<Vec<TelemetryInterfaceConfig<'static>>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,10 @@ async fn main() -> eyre::Result<()> {
             .wrap_err("Unable to create store directory")?;
     }
 
+    if options.interfaces_directory.is_some() {
+        warn!("DEPRECATED: the interface directory is no longer used as the interfaces are bundled")
+    }
+
     info!(
         "Using {} as store directory",
         options.store_directory.display()
@@ -97,12 +101,7 @@ async fn main() -> eyre::Result<()> {
                 .ok_or_eyre("couldn't get astarte options")?;
 
             let client = astarte_sdk_options
-                .connect(
-                    &mut tasks,
-                    store,
-                    &options.store_directory,
-                    &options.interfaces_directory,
-                )
+                .connect(&mut tasks, store, &options.store_directory)
                 .await?;
 
             let mut runtime =
@@ -123,7 +122,7 @@ async fn main() -> eyre::Result<()> {
                 .ok_or_eyre("couldn't get MessageHub options")?;
 
             let client = astarte_message_hub_options
-                .connect(&mut tasks, store, &options.interfaces_directory)
+                .connect(&mut tasks, store, &options.store_directory)
                 .await?;
 
             let mut runtime =


### PR DESCRIPTION
This will not require to include the interfaces repo in the edgehog
installation, and the correct interfaces are added based on the features
the binary is compiled with.